### PR TITLE
Add MySet dataset utilities

### DIFF
--- a/config/config_myset.yaml
+++ b/config/config_myset.yaml
@@ -1,0 +1,21 @@
+PATHS:
+  myset_root: "/data/Open3DSG_trainset"
+  checkpoints: "/data/Open3DSG_trainset/checkpoints"
+  features_out: "open3dsg/output/features/myset"
+  preproc_out:  "open3dsg/output/preprocessed/myset"
+  graphs_out:   "open3dsg/output/graphs/myset"
+
+DATASET:
+  name: "myset"
+  use_rgb: true
+  top_k_frames: 5
+  scales: 3
+
+TRAINING:
+  epochs: 100
+  batch_size: 4
+  workers: 8
+  gpus: 4
+  mixed_precision: true
+  clip_model: "OpenSeg"
+  blip: true

--- a/open3dsg/config/config.py
+++ b/open3dsg/config/config.py
@@ -35,6 +35,13 @@ CONF.PATH.SCANNET = os.path.join(CONF.PATH.DATA_OUT, "datasets", "OpenSG_ScanNet
 CONF.PATH.CHECKPOINTS = os.path.join(CONF.PATH.DATA_OUT, "checkpoints")
 CONF.PATH.FEATURES = os.path.join(CONF.PATH.DATA_OUT, "features")
 
+# Custom dataset example
+CONF.PATH.MYSET_ROOT = "/data/Open3DSG_trainset"
+CONF.PATH.MYSET_CHECKPOINTS = os.path.join(CONF.PATH.MYSET_ROOT, "checkpoints")
+CONF.PATH.MYSET_FEATURES_OUT = "open3dsg/output/features/myset"
+CONF.PATH.MYSET_PREPROC_OUT = "open3dsg/output/preprocessed/myset"
+CONF.PATH.MYSET_GRAPHS_OUT = "open3dsg/output/graphs/myset"
+
 # MLOps
 CONF.PATH.MLOPS = os.path.join(CONF.PATH.BASE, "mlops")  # MLOps directory
 CONF.PATH.MLFLOW = os.path.join(CONF.PATH.MLOPS, "opensg", "mlflow")  # Output directory for MLFlow data

--- a/open3dsg/data/datasets/__init__.py
+++ b/open3dsg/data/datasets/__init__.py
@@ -1,0 +1,5 @@
+from .myset import MySetDataset
+
+DATASETS = {
+    "myset": MySetDataset,
+}

--- a/open3dsg/data/datasets/myset.py
+++ b/open3dsg/data/datasets/myset.py
@@ -1,0 +1,62 @@
+import json
+import pickle
+from pathlib import Path
+from typing import Dict, Any
+
+import torch
+
+
+class BaseDataset:
+    """Minimal base dataset."""
+
+    def __init__(self, cfg: Dict[str, Any], split: str = "train"):
+        self.cfg = cfg
+        self.split = split
+
+    def __len__(self):
+        raise NotImplementedError
+
+    def get_item(self, idx: int) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class MySetDataset(BaseDataset):
+    """Lightweight adapter for custom dataset layout."""
+
+    NAME = "myset"
+
+    def __init__(self, cfg: Dict[str, Any], split: str = "train"):
+        super().__init__(cfg, split)
+        paths = cfg.get("PATHS", {})
+        myset = paths.get("myset", {})
+        self.paths = {
+            "root": Path(myset.get("root", "/data/Open3DSG_trainset")),
+            "graphs": Path(myset.get("graphs_out", "open3dsg/output/graphs/myset")) / "graphs",
+            "cache": Path(myset.get("preproc_out", "open3dsg/output/preprocessed/myset")) / "cache",
+            "frames": Path(myset.get("preproc_out", "open3dsg/output/preprocessed/myset")) / "frames",
+        }
+        graphs_file = self.paths["graphs"] / f"{split}.json"
+        self.graph_db = json.loads(graphs_file.read_text()) if graphs_file.exists() else {}
+        self.scan_ids = sorted(self.graph_db.keys())
+
+    def __len__(self) -> int:
+        return len(self.scan_ids)
+
+    def _load_scene(self, idx: int) -> Dict[str, Any]:
+        scan_id = self.scan_ids[idx]
+        points = torch.load(self.paths["cache"] / f"{scan_id}_pc.pt")
+        with open(self.paths["cache"] / f"{scan_id}_instances.pkl", "rb") as f:
+            instances = pickle.load(f)
+        graph = self.graph_db[scan_id]
+        frames_map_path = self.paths["frames"] / f"{scan_id}.json"
+        frames_map = json.loads(frames_map_path.read_text()) if frames_map_path.exists() else {}
+        return {
+            "scan_id": scan_id,
+            "points": points,
+            "instances": instances,
+            "graph": graph,
+            "frames": frames_map,
+        }
+
+    def get_item(self, idx: int) -> Dict[str, Any]:
+        return self._load_scene(idx)

--- a/open3dsg/data/gen_myset_subgraphs.py
+++ b/open3dsg/data/gen_myset_subgraphs.py
@@ -1,0 +1,73 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import open3d as o3d
+
+
+def load_ply_points(path: Path):
+    pc = o3d.io.read_point_cloud(str(path))
+    return np.asarray(pc.points)
+
+
+def compute_aabb(points: np.ndarray):
+    mn = points.min(axis=0)
+    mx = points.max(axis=0)
+    return [mn.tolist(), mx.tolist()]
+
+
+def build_graph_for_scan(scan_dir: Path, inst_dir_name: str = "mask/vis_instances"):
+    inst_files = sorted(Path(scan_dir, inst_dir_name).glob("inst_*.ply"))
+    nodes = []
+    centers = []
+    for i, f in enumerate(inst_files):
+        pts = load_ply_points(f)
+        aabb = compute_aabb(pts)
+        centroid = pts.mean(axis=0).tolist()
+        nodes.append({
+            "inst_id": i,
+            "file": str(f.relative_to(scan_dir)),
+            "centroid": centroid,
+            "aabb": aabb,
+            "n_points": int(pts.shape[0])
+        })
+        centers.append(np.array(centroid))
+
+    centers = np.stack(centers) if len(centers) else np.zeros((0, 3))
+    edges = []
+    if len(nodes) > 1:
+        diags = [np.linalg.norm(np.array(n["aabb"][1]) - np.array(n["aabb"][0])) for n in nodes]
+        mean_diag = float(np.mean(diags)) if diags else 1.0
+        thresh = 1.5 * mean_diag
+        for i in range(len(nodes)):
+            for j in range(i + 1, len(nodes)):
+                if np.linalg.norm(centers[i] - centers[j]) < thresh:
+                    edges.append([i, j, "spatial"])
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--split", default="train")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    scans = sorted([p for p in root.iterdir() if p.is_dir() and p.name.startswith("scan")])
+
+    graphs = {}
+    for scan in scans:
+        scan_id = scan.name
+        graphs[scan_id] = build_graph_for_scan(scan)
+
+    out_dir = Path(args.out) / "graphs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"{args.split}.json").write_text(json.dumps(graphs))
+    print(f"Wrote {len(graphs)} graphs to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/open3dsg/data/get_object_frame_myset.py
+++ b/open3dsg/data/get_object_frame_myset.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import open3d as o3d
+from scipy.spatial.transform import Rotation as R
+
+
+def load_cam(meta_file: Path):
+    m = json.loads(meta_file.read_text())
+    fx, fy = m["fx"], m["fy"]
+    cx, cy = m["cx"], m["cy"]
+    K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]], dtype=np.float32)
+    w, h = m["width"], m["height"]
+
+    quat = [m["qw"], m["qx"], m["qy"], m["qz"]]
+    rot = R.from_quat([quat[1], quat[2], quat[3], quat[0]]).as_matrix()
+    trans = np.array([m["tx"], m["ty"], m["tz"]], dtype=np.float32)
+
+    T = np.eye(4, dtype=np.float32)
+    T[:3, :3] = rot
+    T[:3, 3] = trans
+    return K, T, w, h
+
+
+def project_points(pts_cam, K):
+    zs = pts_cam[:, 2]
+    uvs = (K @ pts_cam[:, :3].T).T
+    uvs = uvs[:, :2] / zs[:, None]
+    return uvs, zs
+
+
+def visible_ratio(points_world, K, T_world_cam, w, h):
+    pts_world_h = np.concatenate([points_world, np.ones((points_world.shape[0], 1))], axis=1)
+    pts_cam = (np.linalg.inv(T_world_cam) @ pts_world_h.T).T[:, :3]
+    infront = pts_cam[:, 2] > 0
+    if not np.any(infront):
+        return 0.0
+    uvs, _ = project_points(pts_cam[infront], K)
+    inside = (uvs[:, 0] >= 0) & (uvs[:, 0] < w) & (uvs[:, 1] >= 0) & (uvs[:, 1] < h)
+    return float(inside.sum()) / float(points_world.shape[0])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True, help="dataset root")
+    ap.add_argument("--out", required=True, help="output dir for frames json")
+    ap.add_argument("--top_k", type=int, default=5)
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    scans = sorted([p for p in root.iterdir() if p.is_dir() and p.name.startswith("scan")])
+
+    for scan in scans:
+        scan_id = scan.name
+        inst_paths = sorted((scan / "mask/vis_instances").glob("inst_*.ply"))
+        inst_pts = [np.asarray(o3d.io.read_point_cloud(str(p)).points) for p in inst_paths]
+
+        img_files = sorted(scan.glob("image_*.*"))
+        frame_scores = {}
+
+        for inst_idx, pts in enumerate(inst_pts):
+            scores = []
+            for img_path in img_files:
+                idx = int(img_path.stem.split("_")[-1])
+                meta = scan / f"im_metadata_{idx}.json"
+                if not meta.exists():
+                    continue
+                K, T, w, h = load_cam(meta)
+                score = visible_ratio(pts, K, T, w, h)
+                scores.append((idx, score))
+            top = sorted(scores, key=lambda x: -x[1])[: args.top_k]
+            frame_scores[int(inst_idx)] = [i for i, _ in top]
+
+        (out_dir / f"{scan_id}.json").write_text(json.dumps(frame_scores))
+        print(f"{scan_id}: {len(inst_paths)} instances processed")
+
+
+if __name__ == "__main__":
+    main()

--- a/open3dsg/data/preprocess_myset.py
+++ b/open3dsg/data/preprocess_myset.py
@@ -1,0 +1,61 @@
+import argparse
+import json
+import pickle
+from pathlib import Path
+
+import numpy as np
+import open3d as o3d
+import torch
+from tqdm import tqdm
+
+
+def o3d_load(p: Path):
+    pc = o3d.io.read_point_cloud(str(p))
+    pts = np.asarray(pc.points)
+    if pc.has_colors():
+        cols = np.asarray(pc.colors)
+        arr = np.concatenate([pts, cols], axis=1)
+    else:
+        arr = pts
+    return arr
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--graphs", required=True, help="graphs/train.json")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    graphs = json.loads(Path(args.graphs).read_text())
+
+    out_cache = Path(args.out) / "cache"
+    out_cache.mkdir(parents=True, exist_ok=True)
+
+    for scan_id, g in tqdm(graphs.items()):
+        scan_dir = root / scan_id
+        raw_candidates = list(scan_dir.glob(f"{scan_id}.*"))
+        if not raw_candidates:
+            raise FileNotFoundError(f"No raw cloud for {scan_id}")
+        raw_cloud = raw_candidates[0]
+        arr = o3d_load(raw_cloud)
+        torch.save(torch.from_numpy(arr).float(), out_cache / f"{scan_id}_pc.pt")
+
+        inst_meta = []
+        for node in g["nodes"]:
+            inst_meta.append({
+                "inst_id": node["inst_id"],
+                "file": node["file"],
+                "centroid": node["centroid"],
+                "aabb": node["aabb"],
+                "n_points": node["n_points"],
+            })
+        with open(out_cache / f"{scan_id}_instances.pkl", "wb") as fw:
+            pickle.dump(inst_meta, fw)
+
+    print("Preprocessing finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_myset_train.sh
+++ b/scripts/run_myset_train.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+ROOT=/data/Open3DSG_trainset
+OUT_GRAPH=open3dsg/output/graphs/myset
+OUT_PREPROC=open3dsg/output/preprocessed/myset
+
+python open3dsg/data/gen_myset_subgraphs.py --root $ROOT --out $OUT_GRAPH --split train
+python open3dsg/data/get_object_frame_myset.py --root $ROOT --out $OUT_PREPROC/frames --top_k 5
+python open3dsg/data/preprocess_myset.py --root $ROOT --graphs $OUT_GRAPH/graphs/train.json --out $OUT_PREPROC
+
+python open3dsg/scripts/run.py --dump_features --dataset myset \
+  --scales 3 --top_k_frames 5 --clip_model OpenSeg --blip
+
+python open3dsg/scripts/run.py \
+  --epochs 100 --batch_size 4 --gpus 4 --workers 8 \
+  --use_rgb --dataset myset --clip_model OpenSeg --blip \
+  --load_features open3dsg/output/features/myset \
+  --mixed_precision


### PR DESCRIPTION
## Summary
- add configuration example for MySet dataset
- extend config constants with MySet paths
- implement lightweight MySet dataset loader
- add scripts to generate graphs, match frames, and preprocess
- provide convenience training script for MySet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8491fa288320b4ce6b79fb55e894