### PR TITLE
Limit edges per node

### DIFF
--- a/open3dsg/data/gen_myset_subgraphs.py
+++ b/open3dsg/data/gen_myset_subgraphs.py
@@ -40,10 +40,21 @@ def build_graph_for_scan(scan_dir: Path, inst_dir_name: str = "mask/vis_instance
         diags = [np.linalg.norm(np.array(n["aabb"][1]) - np.array(n["aabb"][0])) for n in nodes]
         mean_diag = float(np.mean(diags)) if diags else 1.0
         thresh = 1.5 * mean_diag
+
+        pairs = []
         for i in range(len(nodes)):
             for j in range(i + 1, len(nodes)):
-                if np.linalg.norm(centers[i] - centers[j]) < thresh:
-                    edges.append([i, j, "spatial"])
+                d = np.linalg.norm(centers[i] - centers[j])
+                if d < thresh:
+                    pairs.append((d, i, j))
+
+        pairs.sort(key=lambda x: x[0])
+        deg = {i: 0 for i in range(len(nodes))}
+        for _, i, j in pairs:
+            if deg[i] < 10 and deg[j] < 10:
+                edges.append([i, j, "spatial"])
+                deg[i] += 1
+                deg[j] += 1
 
     return {"nodes": nodes, "edges": edges}
 

--- a/open3dsg/util/util_search.py
+++ b/open3dsg/util/util_search.py
@@ -51,7 +51,7 @@ def find_neighbors(points, segments, search_method: SAMPLE_METHODS, receptive_fi
         ''' Search neighbor of each segment '''
         for seg_idx in seg_ids:
             bbox_q = bboxes[seg_idx]
-            seg_n = segs_neighbors[int(seg_idx)] = list()
+            seg_n = []
             for seg_tar_idx in seg_ids:
                 if seg_idx == seg_tar_idx:
                     continue
@@ -59,6 +59,7 @@ def find_neighbors(points, segments, search_method: SAMPLE_METHODS, receptive_fi
                 if (bbox_q[0] > bbox_t[1]).sum() + (bbox_t[0] > bbox_q[1]).sum() > 0:
                     continue
                 seg_n.append(int(seg_tar_idx))
+            segs_neighbors[int(seg_idx)] = seg_n[:10]
     elif search_method == SAMPLE_METHODS.RADIUS:
         # search neighbor for each segments
         for seg_id in seg_ids:
@@ -83,5 +84,5 @@ def find_neighbors(points, segments, search_method: SAMPLE_METHODS, receptive_fi
                 return neighbors
             neighbors = list(f_nn(seg_id, trees, bboxes, segs_pts, receptive_field))
             neighbors = [int(n) for n in neighbors]
-            segs_neighbors[int(seg_idx)] = neighbors
+            segs_neighbors[int(seg_id)] = neighbors[:10]
     return segs_neighbors


### PR DESCRIPTION
## Summary
- restrict edge creation to 10 neighbours in `gen_myset_subgraphs.py`
- cap neighbour list to 10 in `util_search.find_neighbors`

## Testing
- `python -m py_compile open3dsg/data/gen_myset_subgraphs.py open3dsg/util/util_search.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d5c88eb0832099cea0273dbff19b