### PR TITLE
Update preprocess_myset filtering

### DIFF
--- a/open3dsg/data/preprocess_myset.py
+++ b/open3dsg/data/preprocess_myset.py
@@ -110,6 +110,10 @@ def main():
         else:
             obj2frame = {}
 
+        # keep only keys corresponding to nodes that are actually stored
+        kept_idx = set(range(len(objects_pcl)))
+        obj2frame = {k: v for k, v in obj2frame.items() if k in kept_idx}
+
         pairs = []
         edges = []
         triples = []


### PR DESCRIPTION
## Summary
- filter `object2frame` entries that do not have a stored node

## Testing
- `python -m py_compile open3dsg/data/preprocess_myset.py`
- `python open3dsg/data/preprocess_myset.py --root /tmp/dummy --graphs /tmp/dummy/graphs/train.json --frames /tmp/dummy/frames --out /tmp/dummy/out --max_nodes 100 --max_edges_per_node 10` *(fails: `libGL.so.1` missing)*
- `python open3dsg/scripts/run.py --dataset myset --epochs 1 --max_edges 1000 --workers 0 --batch_size 1 --gpus 0 --dummy` *(fails: `torch` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688248ab512883209c2e2e0be79fef86