### PR TITLE
Fix myset preprocessing scaling

### DIFF
--- a/open3dsg/data/get_object_frame_myset.py
+++ b/open3dsg/data/get_object_frame_myset.py
@@ -257,6 +257,24 @@ def main():
                     print(f"[WARN] {scan_id} frame {idx}: {e}")
                     continue
                 vis, pix_cnt, bbox, pix_ids = projection_details(pts, K, T, w, h)
+                # normalize pixel coordinates to 320x240 so downstream loaders
+                # can directly index the resized features
+                scale_x = 320.0 / float(w)
+                scale_y = 240.0 / float(h)
+                bbox = (
+                    int(np.clip(round(bbox[0] * scale_x), 0, 319)),
+                    int(np.clip(round(bbox[1] * scale_y), 0, 239)),
+                    int(np.clip(round(bbox[2] * scale_x), 0, 319)),
+                    int(np.clip(round(bbox[3] * scale_y), 0, 239)),
+                )
+                if pix_ids.size:
+                    pix_ids = np.stack(
+                        (
+                            np.clip(np.round(pix_ids[:, 0] * scale_x), 0, 319),
+                            np.clip(np.round(pix_ids[:, 1] * scale_y), 0, 239),
+                        ),
+                        axis=1,
+                    ).astype(np.uint16)
                 scores.append((idx, vis))
                 # store the frame file name instead of numeric index so the
                 # dataset loader can directly resolve the image path

--- a/scripts/run_myset_train.sh
+++ b/scripts/run_myset_train.sh
@@ -7,13 +7,16 @@ OUT_PREPROC=open3dsg/output/preprocessed/myset
 
 python open3dsg/data/gen_myset_subgraphs.py --root $ROOT --out $OUT_GRAPH --split train
 python open3dsg/data/get_object_frame_myset.py --root $ROOT --out $OUT_PREPROC/frames --top_k 5
-python open3dsg/data/preprocess_myset.py --root $ROOT --graphs $OUT_GRAPH/graphs/train.json --out $OUT_PREPROC
+python open3dsg/data/preprocess_myset.py --root $ROOT \
+  --graphs $OUT_GRAPH/graphs/train.json --frames $OUT_PREPROC/frames \
+  --out $OUT_PREPROC --max_edges_per_node 10 --max_nodes 10
 
 python open3dsg/scripts/run.py --dump_features --dataset myset \
-  --scales 3 --top_k_frames 5 --clip_model OpenSeg --blip
+  --scales 3 --top_k_frames 5 --clip_model OpenSeg --blip \
+  --max_nodes 10 --max_edges 100
 
 python open3dsg/scripts/run.py \
   --epochs 100 --batch_size 4 --gpus 4 --workers 8 \
   --use_rgb --dataset myset --clip_model OpenSeg --blip \
   --load_features open3dsg/output/features/myset \
-  --mixed_precision
+  --mixed_precision --max_nodes 10 --max_edges 100


### PR DESCRIPTION
## Summary
- normalize pixel coordinates in `get_object_frame_myset.py` to 320x240
- set limits for preprocessing/training in `run_myset_train.sh`

## Testing
- `python -m py_compile open3dsg/data/get_object_frame_myset.py`

------
https://chatgpt.com/codex/tasks/task_e_688358029c7c83209732d70a08139163