### PR TITLE
Fix feature dumping opt scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This is an **optional** step to accelerate the forward pass in the training loop
 python open3dsg/scripts/run.py --dump_features --dataset [scannet/3rscan] --scales 3 --top_k_frames 5 --clip_model OpenSeg --blip
 ```
 
+Running with `--dump_features` only extracts the features without training and disables the learning rate scheduler.
+
 In case of out of memory issues, seperate the BLIP export & the OpenSeg export.
 
 ## Train

--- a/open3dsg/scripts/trainer.py
+++ b/open3dsg/scripts/trainer.py
@@ -211,6 +211,9 @@ class D3SSGModule(lightning.LightningModule):
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.model.parameters(), self.hparams['lr'], weight_decay=1e-5)
 
+        if self.hparams.get("dump_features"):
+            return optimizer
+
         if self.hparams['lr_scheduler'] == 'cyclic':
             lr_scheduler = torch.optim.lr_scheduler.CyclicLR(
                 optimizer, base_lr=self.hparams['lr']-(self.hparams['lr']/2),


### PR DESCRIPTION
## Summary
- return only optimizer when dumping features
- clarify in README that `--dump_features` skips training and disables LR scheduling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883929b9d788320880535d2e528c556