### PR TITLE
Fix pixel scaling axis order

### DIFF
--- a/open3dsg/data/get_object_frame_myset.py
+++ b/open3dsg/data/get_object_frame_myset.py
@@ -270,8 +270,8 @@ def main():
                 if pix_ids.size:
                     pix_ids = np.stack(
                         (
-                            np.clip(np.round(pix_ids[:, 0] * scale_x), 0, 319),
-                            np.clip(np.round(pix_ids[:, 1] * scale_y), 0, 239),
+                            np.clip(np.round(pix_ids[:, 1] * scale_y), 0, 239),  # row (y)
+                            np.clip(np.round(pix_ids[:, 0] * scale_x), 0, 319),  # column (x)
                         ),
                         axis=1,
                     ).astype(np.uint16)


### PR DESCRIPTION
## Summary
- correct axis order when scaling pixel indices in `get_object_frame_myset.py`

## Testing
- `python open3dsg/data/get_object_frame_myset.py --root /data/Open3DSG_trainset --out open3dsg/output/preprocessed/myset/frames --top_k 5` *(fails: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688396e140f88320bd56524ba078a42d