### PR TITLE
Fix weights loading

### DIFF
--- a/open3dsg/models/sgpn.py
+++ b/open3dsg/models/sgpn.py
@@ -39,7 +39,10 @@ if gpus:
 dummy_text_emb = tf.zeros([1, 1, 768])
 
 
-blip2_positional_encoding = torch.load(os.path.join(CONF.PATH.CHECKPOINTS, 'blip2_positional_embedding.pt'))
+blip2_positional_encoding = torch.load(
+    os.path.join(CONF.PATH.CHECKPOINTS, 'blip2_positional_embedding.pt'),
+    weights_only=False
+)
 
 
 class SGPN(nn.Module):
@@ -142,16 +145,24 @@ class SGPN(nn.Module):
             pth = os.path.join(CONF.PATH.CHECKPOINTS, 'pointnet2_ulip.pt')
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
-                pretrained_dict = torch.load(pth, map_location=torch.device(torch.distributed.get_rank()))["state_dict"]
+                pretrained_dict = torch.load(
+                    pth,
+                    weights_only=False,
+                    map_location=torch.device(torch.distributed.get_rank())
+                )["state_dict"]
             else:
-                pretrained_dict = torch.load(pth)["state_dict"]
+                pretrained_dict = torch.load(pth, weights_only=False)["state_dict"]
         else:
             pth = os.path.join(CONF.PATH.CHECKPOINTS, 'pointnet.pth')
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
-                pretrained_dict = torch.load(pth, map_location=torch.device(torch.distributed.get_rank()))["model_state_dict"]
+                pretrained_dict = torch.load(
+                    pth,
+                    weights_only=False,
+                    map_location=torch.device(torch.distributed.get_rank())
+                )["model_state_dict"]
             else:
-                pretrained_dict = torch.load(pth)["model_state_dict"]
+                pretrained_dict = torch.load(pth, weights_only=False)["model_state_dict"]
 
             net_state_dict = model.state_dict()
             pretrained_dict_ = {k[5:]: v for k, v in pretrained_dict.items() if 'feat' in k and v.size() == net_state_dict[k[5:]].size()}


### PR DESCRIPTION
## Summary
- load BLIP2 positional encoding without `weights_only`
- avoid `weights_only=True` errors in pretrained loading

## Testing
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a3615fac483208aa19650223f55ce