### PR TITLE
Enable multi-GPU profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ python open3dsg/scripts/vram_profile.py --dataset scannet --clip_model OpenSeg -
 The profiler also supports `--dump_features` to measure memory
 consumption during 2D feature precomputing and `--load_features` to
 profile training when precomputed features are loaded from disk.
+Use `--gpus 2` (or `--gpu_ids 0,1`) to profile with multiple GPUs
+via `DataParallel`.
 
 
 ## Train


### PR DESCRIPTION
## Summary
- extend `vram_profile.py` with DataParallel options
- support moving batch across GPUs
- document multi-GPU profiling in README

## Testing
- `pytest -q`
- `python -m py_compile open3dsg/scripts/vram_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_688b791b7d08832087b4d3b0ced092ae