### PR TITLE
Clear GPU memory during VRAM profiling

### DIFF
--- a/open3dsg/scripts/vram_profile.py
+++ b/open3dsg/scripts/vram_profile.py
@@ -130,10 +130,13 @@ def profile_gpu(device_id: int, args, hparams):
                 )
             else:
                 _ = model.clip_encode_imgs(batch_gpu["object_imgs"], batch_gpu["relationship_imgs"])
+            torch.cuda.empty_cache()
             if args.blip:
                 _ = model.blip_encode_images(batch_gpu["blip_images"])
+                torch.cuda.empty_cache()
             elif args.llava:
                 _ = model.llava_encode_images(batch_gpu["blip_images"])
+                torch.cuda.empty_cache()
         else:
             _ = model(batch_gpu)
     record_vram("After inference", results)


### PR DESCRIPTION
## Summary
- free GPU memory between OpenSeg/CLIP and BLIP/LLaVA feature steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688ca9ef35e0832080182ab95b9f01b9