### PR TITLE
Add skip_edge_features option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ python open3dsg/scripts/run.py --dump_features --dataset [scannet/3rscan] --scal
 
 Running with `--dump_features` only extracts the features without training and disables the learning rate scheduler.
 
-In case of out of memory issues, seperate the BLIP export & the OpenSeg export.
+In case of out of memory issues, use `--skip_edge_features` to export only the node
+features first. Afterwards run the command again with `--blip` to dump relation
+embeddings.
 
 ## Profile GPU Memory
 

--- a/open3dsg/models/sgpn.py
+++ b/open3dsg/models/sgpn.py
@@ -413,7 +413,7 @@ class SGPN(nn.Module):
                 obj_clip_encoding = self.CLIP.encode_image(obj_imgs_batched).view(*obj_imgs.shape[:-3], -1)
             obj_clip_encoding = obj_clip_encoding/obj_clip_encoding.norm(dim=-1, keepdim=True)
 
-            if not self.hparams.get('blip') or not self.hparams.get('llava'):
+            if not self.hparams.get('skip_edge_features') and self.CLIP is not None and not self.hparams.get('blip') and not self.hparams.get('llava'):
                 rel_img_dim = rel_imgs.shape[-2:]
                 rel_imgs_batched = rel_imgs.view(-1, 3, *rel_img_dim)
                 if self.hparams['edge_model']:
@@ -452,7 +452,7 @@ class SGPN(nn.Module):
                     pts = obj_points[batch][node][view]
                     obj_embedding[batch][node][view] = feat_2d[pts[:, 0], pts[:, 1]].mean(axis=0)
 
-        if not self.hparams.get('blip') and not self.hparams.get('llava'):
+        if not self.hparams.get('skip_edge_features') and self.CLIP is not None and not self.hparams.get('blip') and not self.hparams.get('llava'):
             rel_img_dim = rel_imgs.shape[-2:]
             with torch.no_grad():
                 rel_imgs_batched = rel_imgs.view(-1, 3, *rel_img_dim)

--- a/open3dsg/scripts/run.py
+++ b/open3dsg/scripts/run.py
@@ -66,6 +66,8 @@ def get_args():
     parser.add_argument("--scales", type=int, default=3, help="number of scales for each selected image")
     parser.add_argument('--dump_features', action="store_true", help="precompute 2d features and dump to disk")
     parser.add_argument('--load_features', default=None, help="path to precomputed 2d features")
+    parser.add_argument('--skip_edge_features', action='store_true',
+                        help='Skip relation image feature computation')
 
     # model variations params
     parser.add_argument('--clip_model', default="OpenSeg", type=str,

--- a/open3dsg/scripts/trainer.py
+++ b/open3dsg/scripts/trainer.py
@@ -141,7 +141,8 @@ class D3SSGModule(lightning.LightningModule):
                 blip=self.hparams.get('blip', False),
                 llava=self.hparams.get('llava', False),
                 max_objects=self.hparams.get('max_nodes', None),
-                max_rels=self.hparams.get('max_edges', None)
+                max_rels=self.hparams.get('max_edges', None),
+                skip_edge_features=self.hparams.get('skip_edge_features', False)
             )
 
             # load pre-trained models
@@ -575,11 +576,13 @@ class D3SSGModule(lightning.LightningModule):
             obj_valid_path = os.path.join(path, 'export_obj_clip_valids')
             os.makedirs(obj_path, exist_ok=True)
             os.makedirs(obj_valid_path, exist_ok=True)
-            os.makedirs(rel_path, exist_ok=True)
+            if clip_rel_emb_masked is not None:
+                os.makedirs(rel_path, exist_ok=True)
 
             torch.save(clip_obj_emb.detach().cpu(), os.path.join(obj_path, data_dict['scan_id'][bidx]+'.pt'))
             torch.save(obj_valids.detach().cpu(), os.path.join(obj_valid_path, data_dict['scan_id'][bidx]+'.pt'))
-            torch.save(clip_rel_emb_masked.detach().cpu(), os.path.join(rel_path, data_dict['scan_id'][bidx]+'.pt'))
+            if clip_rel_emb_masked is not None:
+                torch.save(clip_rel_emb_masked.detach().cpu(), os.path.join(rel_path, data_dict['scan_id'][bidx]+'.pt'))
 
     @torch.no_grad()
     def _predict_obj_from_clip(self, data_dict, batch_size, query_classes=None, from_distill=True):

--- a/open3dsg/scripts/vram_profile.py
+++ b/open3dsg/scripts/vram_profile.py
@@ -107,6 +107,7 @@ def profile_gpu(device_id: int, args, hparams):
         load_features=args.load_features,
         blip=args.blip,
         llava=args.llava,
+        skip_edge_features=args.skip_edge_features,
     )
     loader = DataLoader(
         dataset,
@@ -174,6 +175,10 @@ def main():
     parser.add_argument(
         "--load_features", default=None, help="path to precomputed 2D features"
     )
+    parser.add_argument(
+        "--skip_edge_features", action="store_true",
+        help="Skip relation image feature computation",
+    )
     parser.add_argument("--pointnet2", action="store_true")
     parser.add_argument("--clean_pointnet", action="store_true")
     parser.add_argument("--top_k_frames", type=int, default=5)
@@ -213,6 +218,7 @@ def main():
         "max_edges": args.max_edges,
         "load_features": args.load_features,
         "dump_features": args.dump_features,
+        "skip_edge_features": args.skip_edge_features,
         "test": False,
     }
 


### PR DESCRIPTION
## Summary
- add new `--skip_edge_features` flag to run and vram_profile scripts
- support skipping relation image computation in dataset and model
- handle missing relation features when loading from disk
- only dump relation features if available
- document using `--skip_edge_features` in README

## Testing
- `python -m py_compile open3dsg/scripts/run.py open3dsg/scripts/trainer.py open3dsg/scripts/vram_profile.py open3dsg/data/open_dataset.py open3dsg/models/sgpn.py`

------
https://chatgpt.com/codex/tasks/task_e_688cc9843c708320b655883f54c4da61