### PR TITLE
Add scripts for subgraph merging and full-graph preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ In case of out of memory issues, use `--skip_edge_features` to export only the n
 features first. Afterwards run the command again with `--blip` to dump relation
 embeddings.
 
+### Precompute Full Graphs
+
+Scenes with many objects can exceed GPU memory when dumping features. The helper
+script below splits each ScanNet scene into subgraphs, dumps features per
+subgraph and merges them back into a full graph.
+
+```bash
+python open3dsg/scripts/precompute_full_graph.py --split train --out_dir <output_dir>
+```
+
+The script writes `relationships_<split>_full.json` and the merged feature
+files into the chosen output directory. These can be used with
+`--load_features` for training large scenes.
+
 ## Profile GPU Memory
 
 To inspect GPU memory usage of each pretrained component run:

--- a/open3dsg/data/merge_subgraphs.py
+++ b/open3dsg/data/merge_subgraphs.py
@@ -1,0 +1,111 @@
+import argparse
+import json
+import os
+import pickle
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+
+from open3dsg.config.config import CONF
+
+
+def load_feature_dirs(features_dir: Path):
+    obj_dir = None
+    valid_dir = None
+    rel_dir = None
+    for d in features_dir.iterdir():
+        name = d.name
+        if "export_obj_clip_emb" in name:
+            obj_dir = d
+        elif "export_obj_clip_valids" in name:
+            valid_dir = d
+        elif "export_rel_clip_emb" in name:
+            rel_dir = d
+    return obj_dir, valid_dir, rel_dir
+
+
+def merge_subgraphs(split: str, features_dir: Path, out_dir: Path,
+                     preproc_dir: Path, subgraph_dir: Path):
+    rel_file = subgraph_dir / f"relationships_{split}.json"
+    data = json.loads(rel_file.read_text())
+    scans = defaultdict(list)
+    neighbors = data.get("neighbors", {})
+    for r in data["scans"]:
+        scans[r["scan"]].append(r)
+
+    obj_dir, valid_dir, rel_dir = load_feature_dirs(features_dir)
+    out_obj_dir, out_valid_dir, out_rel_dir = load_feature_dirs(out_dir)
+    out_obj_dir.mkdir(parents=True, exist_ok=True)
+    out_valid_dir.mkdir(parents=True, exist_ok=True)
+    if rel_dir:
+        out_rel_dir.mkdir(parents=True, exist_ok=True)
+
+    merged_scans = []
+    for scan_id, rels in scans.items():
+        objects = {}
+        rel_list = []
+        obj_feats = {}
+        obj_valids = {}
+        edge_pairs = set()
+        for rel in rels:
+            split_idx = rel["split"]
+            sg_name = f"{scan_id}-{hex(split_idx)[-1]}"
+            pkl_path = preproc_dir / scan_id / f"data_dict_{hex(split_idx)[-1]}.pkl"
+            if pkl_path.exists():
+                data_dict = pickle.load(open(pkl_path, "rb"))
+                obj_ids = data_dict["objects_id"]
+                feats = torch.load(obj_dir / f"{sg_name}.pt")
+                valids = torch.load(valid_dir / f"{sg_name}.pt")
+                for oid, feat, val in zip(obj_ids, feats, valids):
+                    if oid not in obj_feats:
+                        obj_feats[oid] = feat
+                        obj_valids[oid] = val
+            objects.update({int(k): v for k, v in rel["objects"].items()})
+            rel_list.extend(rel.get("relationships", []))
+            edge_pairs.update({(r[0], r[1]) for r in rel.get("relationships", [])})
+
+        # add cross-subgraph edges
+        neigh = neighbors.get(scan_id, {})
+        for k, nbs in neigh.items():
+            k = int(k)
+            for nb in nbs:
+                pair = (k, nb)
+                if pair not in edge_pairs and k in objects and nb in objects:
+                    rel_list.append([k, nb, 0])
+                    edge_pairs.add(pair)
+
+        # save merged features
+        if obj_feats:
+            ids_sorted = sorted(obj_feats.keys())
+            feats = torch.stack([obj_feats[i] for i in ids_sorted])
+            valids = torch.stack([obj_valids[i] for i in ids_sorted])
+            torch.save(feats, out_obj_dir / f"{scan_id}.pt")
+            torch.save(valids, out_valid_dir / f"{scan_id}.pt")
+        merged_scans.append({
+            "scan": scan_id,
+            "split": 0,
+            "objects": {str(i): objects[i] for i in sorted(objects)},
+            "relationships": rel_list,
+        })
+
+    out_json = out_dir / f"relationships_{split}_full.json"
+    with open(out_json, "w") as f:
+        json.dump({"scans": merged_scans}, f)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge ScanNet subgraphs")
+    parser.add_argument("--split", required=True, choices=["train", "validation", "test"], help="dataset split")
+    parser.add_argument("--features_dir", required=True, help="directory with subgraph features")
+    parser.add_argument("--out_dir", required=True, help="output directory")
+    parser.add_argument("--preproc_dir", default=os.path.join(CONF.PATH.SCANNET, "preprocessed"))
+    parser.add_argument("--subgraph_dir", default=os.path.join(CONF.PATH.SCANNET, "subgraphs"))
+    args = parser.parse_args()
+
+    merge_subgraphs(args.split, Path(args.features_dir), Path(args.out_dir),
+                    Path(args.preproc_dir), Path(args.subgraph_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/open3dsg/scripts/precompute_full_graph.py
+++ b/open3dsg/scripts/precompute_full_graph.py
@@ -1,0 +1,62 @@
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from open3dsg.config.config import CONF
+
+
+def run_cmd(cmd):
+    print(" ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+def latest_feature_dir(base: Path) -> Path:
+    dirs = [d for d in base.iterdir() if d.is_dir() and d.name.startswith("clip_features_")]
+    return max(dirs, key=lambda p: p.stat().st_mtime)
+
+
+def precompute_full(split: str, out_dir: Path, extra_args: str = ""):
+    subgraph_dir = Path(CONF.PATH.SCANNET) / "subgraphs"
+    preproc_dir = Path(CONF.PATH.SCANNET) / "preprocessed"
+
+    run_cmd(["python", "open3dsg/data/gen_scannet_subgraphs.py", "--type", split])
+    run_cmd(["python", "open3dsg/data/preprocess_scannet.py"])
+
+    dump_cmd = ["python", "open3dsg/scripts/run.py", "--dump_features", "--dataset", "scannet"]
+    if extra_args:
+        dump_cmd.extend(extra_args.split())
+    run_cmd(dump_cmd)
+
+    feat_dir = latest_feature_dir(Path(CONF.PATH.FEATURES))
+    merge_cmd = [
+        "python",
+        "open3dsg/data/merge_subgraphs.py",
+        "--split",
+        split,
+        "--features_dir",
+        str(feat_dir),
+        "--out_dir",
+        str(out_dir),
+        "--preproc_dir",
+        str(preproc_dir),
+        "--subgraph_dir",
+        str(subgraph_dir),
+    ]
+    run_cmd(merge_cmd)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Precompute full graphs")
+    parser.add_argument("--split", default="train", choices=["train", "validation", "test"])
+    parser.add_argument("--out_dir", required=True, help="directory to store merged features")
+    parser.add_argument("--extra_args", default="", help="additional args passed to run.py")
+    args = parser.parse_args()
+
+    precompute_full(args.split, Path(args.out_dir), args.extra_args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `merge_subgraphs.py` for consolidating ScanNet subgraphs
- add `precompute_full_graph.py` automation pipeline
- document usage of the new pipeline in README

## Testing
- `python -m py_compile open3dsg/data/merge_subgraphs.py open3dsg/scripts/precompute_full_graph.py`

------
https://chatgpt.com/codex/tasks/task_e_688cde93f51883208ca03f0afd3286fc