### PR TITLE
Add BLIP image encoding batch size CLI option

### DIFF
--- a/open3dsg/scripts/run.py
+++ b/open3dsg/scripts/run.py
@@ -80,6 +80,7 @@ def get_args():
     parser.add_argument('--avg_blip_emb', action='store_true', help="Average the blip embeddings across patches")
     parser.add_argument('--blip_proj_layers', type=int, default=3,
                         help="Number of projection layers to match blip embedding")
+    parser.add_argument('--blip_batch_size', type=int, default=32, help='Batch size for BLIP image encoding')
     parser.add_argument('--llava', action="store_true", help="Use llava for relation prediction")
     parser.add_argument('--avg_llava_emb', action="store_true", help="Average the llava embeddings across patches")
     parser.add_argument('--pointnet2', action="store_true",


### PR DESCRIPTION
## Summary
- allow specifying BLIP image encoding batch size via `--blip_batch_size`

## Testing
- `python -m py_compile open3dsg/scripts/run.py`
- `python open3dsg/scripts/run.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_689099c27ce88320bc8fd128296497da