### PR TITLE
Move feature dumper model to correct device

### DIFF
--- a/open3dsg/scripts/feature_dumper.py
+++ b/open3dsg/scripts/feature_dumper.py
@@ -80,6 +80,11 @@ class FeatureDumper:
         elif self.hparams.get('llava'):
             self.model.load_pretrained_llava_model()
 
+        device = (
+            self.model.clip_device if torch.cuda.is_available() else torch.device("cpu")
+        )
+        self.model.to(device)
+
     def _forward(self, data_dict):
         data_dict = self.model(data_dict)
         return data_dict


### PR DESCRIPTION
## Summary
- ensure FeatureDumper places SGPN model on the same device as the CLIP encoder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c3be606c832093cd96559c82f79d