### PR TITLE
Safely handle feature loading flags

### DIFF
--- a/open3dsg/models/sgpn.py
+++ b/open3dsg/models/sgpn.py
@@ -171,13 +171,12 @@ class SGPN(nn.Module):
 
     def load_pretrained_clip_model(self, target_model, model):
 
-        if self.hparams['load_features'] and not self.hparams['test']:
+        if self.hparams.get("load_features") and not self.hparams.get("test", False):
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
                 clip_model, _ = clip.load('ViT-B/32', device=torch.distributed.get_rank())
                 self.clip_device = torch.device(torch.distributed.get_rank())
             else:
-                torch.distributed.barrier()
                 clip_model, _ = clip.load('ViT-B/32', device='cuda')
                 self.clip_device = "cuda"
             return clip_model

--- a/open3dsg/scripts/feature_dumper.py
+++ b/open3dsg/scripts/feature_dumper.py
@@ -44,6 +44,8 @@ class FeatureDumper:
 
     def __init__(self, hparams):
         self.hparams = hparams
+        self.hparams.setdefault("load_features", False)
+        self.hparams.setdefault("test", False)
         # Only keep lightweight 2D encoders.
         self.model = MinimalSGPN(self.hparams)
 


### PR DESCRIPTION
## Summary
- add default `load_features` and `test` hyperparameters in `FeatureDumper`
- guard `SGPN.load_pretrained_clip_model` against missing hparams and uninitialized distributed mode

## Testing
- `pytest -q`
- `python -m py_compile open3dsg/scripts/feature_dumper.py open3dsg/models/sgpn.py`

------
https://chatgpt.com/codex/tasks/task_e_6891d4f66a6c8320b305fc1901daa494