### PR TITLE
Handle missing relation features in 2D preprocessing

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -60,9 +60,7 @@ def _compute_node_features(args):
             batch["object_imgs"] = batch["object_imgs"].cuda(non_blocking=True)
         with torch.no_grad():
             batch = dumper.encode_features(batch)
-            emb_dim = batch["clip_obj_encoding"].shape[-1]
             bsz = batch["clip_obj_encoding"].shape[0]
-            batch["clip_rel_encoding"] = torch.zeros(bsz, args.max_edges, emb_dim, device=batch["clip_obj_encoding"].device)
             dumper._dump_features(batch, bsz, path=feature_dir)
         del batch
         gc.collect()


### PR DESCRIPTION
## Summary
- remove `CLIP_NONE_EMB` placeholder and zero-fill relation embeddings
- skip relation processing when edge features are absent
- simplify precompute stage 1 to dump only node features

## Testing
- `python -m py_compile open3dsg/scripts/feature_dumper.py open3dsg/scripts/precompute_2d_features.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892054718048320bcb9eb7cc6297ee0