### PR TITLE
fix: avoid device index mismatch in 2d feature precompute

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -143,7 +143,12 @@ def _parse_args():
 
 
 def main_worker(local_rank, args):
-    torch.cuda.set_device(local_rank)
+    # Avoid setting the device based on the spawned process index. This
+    # prevents "invalid device" errors in environments where fewer GPUs are
+    # available than requested. Each model instance will still be created on
+    # the correct device via the `device` argument passed to the `FeatureDumper`.
+    if torch.cuda.is_available():
+        torch.cuda.set_device(0)
     if args.gpus > 1:
         dist.init_process_group(
             "nccl", init_method="tcp://127.0.0.1:29500", rank=local_rank, world_size=args.gpus


### PR DESCRIPTION
## Summary
- avoid selecting CUDA device by spawned process index in `precompute_2d_features.py`
- allow feature dumper workers to initialize even when requested GPUs exceed available

## Testing
- `python open3dsg/scripts/precompute_2d_features.py --gpus 3` *(fails: `FileNotFoundError: MYSET_ROOT: /NetworkDocker/Data/Open3DSG_trainset does not exist (and is required).`)*

------
https://chatgpt.com/codex/tasks/task_e_689227aada2c83208eabedba63546837