### PR TITLE
Remove device_id argument from init_process_group

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -170,7 +170,6 @@ def main_worker(local_rank, args):
             init_method="tcp://127.0.0.1:29500",
             rank=local_rank,
             world_size=args.gpus,
-            device_id=local_rank,
         )
     # Load precomputed node features if provided, otherwise compute them
     if args.load_node_features:


### PR DESCRIPTION
## Summary
- drop `device_id` from `dist.init_process_group` in `precompute_2d_features.py`

## Testing
- `pytest -q`
- `python open3dsg/scripts/precompute_2d_features.py --gpus 2` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689356daab4c8320a96ee4e15931805a