### PR TITLE
Refactor feature precomputation with Lightning Fabric

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ open_clip_torch
 graphviz
 plyfile
 pytorch-lightning==2.1.1
+lightning
 scipy
 setuptools
 tensorflow==2.12.0


### PR DESCRIPTION
## Summary
- Refactor `precompute_2d_features.py` to launch workers via Lightning Fabric instead of manual DDP
- Partition datasets with `DistributedSampler` and `fabric.setup_dataloaders`
- Add `lightning` dependency for Fabric support

## Testing
- `python -m py_compile open3dsg/scripts/precompute_2d_features.py`
- `pip install -r requirements.txt -q` *(fails: RPC failed; HTTP 403 from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_6893615052988320bdc2c3ff9c82f545