### PR TITLE
feat: add distance threshold for mask merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ python open3dsg/script/run.py --test --dataset 3rscan --checkpoint [path to chec
 
 We use the ```CLIP ViT-L/14@336px``` to query object classes from the node embedding. Use ```--n_beams``` to adjust the beam search for the LLM relationship output and ```--weight_2d``` to adjust the 2D-3D features fusion. A value of 0.0 indicates a prediction from 3D features only
 
+## Merge 3D Masks
+
+The repository provides `scripts/merge_3d_masks.py` to combine two 3D mask point
+clouds based on 2D pixel overlap. The script accepts a `--max-dist` option
+specifying the maximum centroid-to-centroid distance allowed for merging
+(`1.0` by default). If the masks are farther apart the merge is skipped.
+
+```bash
+python scripts/merge_3d_masks.py <scan_dir> merged.ply --inst mask_a.ply mask_b.ply --max-dist 1.5
+```
+
+You can visualise the result with `scripts/display_merge.py`:
+
+```bash
+python scripts/display_merge.py mask_a.ply mask_b.ply merged.ply
+```
+
+Only mask pairs within the distance threshold are merged.
+
 ## Citation
 
 If you find our code or paper useful, please cite

--- a/scripts/display_merge.py
+++ b/scripts/display_merge.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Visualise original and merged point clouds side by side."""
+"""Visualise original and merged point clouds side by side.
+
+Only mask pairs that are sufficiently proximal (as determined by
+``merge_3d_masks.py``'s distance threshold) are merged."""
 
 import argparse
 from pathlib import Path

--- a/scripts/merge_3d_masks.py
+++ b/scripts/merge_3d_masks.py
@@ -142,6 +142,12 @@ def main():
         type=int,
         help="RGB frame to use; if omitted the best visible frame is selected",
     )
+    p.add_argument(
+        "--max-dist",
+        type=float,
+        default=1.0,
+        help="maximum centroid-to-centroid distance allowed for merging",
+    )
     args = p.parse_args()
 
     if args.inst:
@@ -157,6 +163,15 @@ def main():
         pc_a = _load_instance_from_scene(scene_pc, args.inst_a)
         pc_b = _load_instance_from_scene(scene_pc, args.inst_b)
         score_a = score_b = 0.0
+
+    center_a = np.asarray(pc_a.get_center())
+    center_b = np.asarray(pc_b.get_center())
+    dist = np.linalg.norm(center_a - center_b)
+    if dist > args.max_dist:
+        print(
+            f"Skipping merge; pair distance {dist:.2f} exceeds threshold {args.max_dist:.2f}"
+        )
+        return
 
     if args.image_idx is not None:
         meta = args.scan_dir / f"im_metadata_{args.image_idx}.json"


### PR DESCRIPTION
## Summary
- allow `scripts/merge_3d_masks.py` to skip merging distant masks via new `--max-dist` option
- note in `display_merge.py` and README that only proximal masks are merged

## Testing
- `python -m py_compile scripts/merge_3d_masks.py scripts/display_merge.py`

------
https://chatgpt.com/codex/tasks/task_e_6893783c26188320af135629327beb53