### PR TITLE
Synchronize GPU before edge feature stage

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -105,6 +105,9 @@ def main_worker(fabric: Fabric, args):
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    fabric.barrier()
 
     # Stage 2: compute edge features
     edge_hparams = {


### PR DESCRIPTION
## Summary
- ensure all GPU work is finished after stage 1 by synchronizing
- pause all processes with a barrier before starting edge feature computation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937e6b9340832099b67c4a82760591