### PR TITLE
Ensure sync between node and edge feature stages

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -105,9 +105,8 @@ def main_worker(fabric: Fabric, args):
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-    fabric.barrier()
+            torch.cuda.synchronize()
+        fabric.barrier()
 
     # Stage 2: compute edge features
     edge_hparams = {


### PR DESCRIPTION
## Summary
- synchronize GPU and add barrier after node feature stage so edge feature stage waits for saved features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937f73bc648320b9b572b28bfe3c42