### PR TITLE
refactor: import Fabric from lightning_fabric

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -6,7 +6,7 @@ import gc
 import torch
 from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
-from lightning import Fabric
+from lightning_fabric import Fabric
 
 from open3dsg.config.config import CONF
 from open3dsg.data.open_dataset import Open2D3DSGDataset


### PR DESCRIPTION
## Summary
- switch precompute_2d_features to lightning_fabric Fabric so no external `lightning` package is needed

## Testing
- `pytest`
- `PYTHONPATH=.:/tmp python open3dsg/scripts/precompute_2d_features.py --help` *(fails: No module named 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_689375c1abd48320bb2a006cce12711d