### PR TITLE
Handle distributed feature dumping per-rank

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -66,11 +66,12 @@ def _parse_args():
     return args
 
 def main_worker(fabric: Fabric, args):
-    rank_dir = str(fabric.global_rank)  # no longer used for output paths
+    rank_dir = str(fabric.global_rank)
 
     # Stage 1: compute node features unless provided
     if args.load_node_features:
         feature_root = args.load_node_features
+        node_feature_dir = feature_root
     else:
         node_hparams = {
             "clip_model": "OpenSeg",
@@ -95,12 +96,13 @@ def main_worker(fabric: Fabric, args):
         )
         loader = fabric.setup_dataloaders(loader)
         feature_root = args.out_dir or dumper.clip_path
-        os.makedirs(feature_root, exist_ok=True)
+        node_feature_dir = os.path.join(feature_root, rank_dir)
+        os.makedirs(node_feature_dir, exist_ok=True)
         for batch in tqdm(loader, desc="Nodes"):
             with torch.no_grad():
                 batch = dumper.encode_features(batch)
                 bsz = batch["clip_obj_encoding"].shape[0]
-                dumper._dump_features(batch, bsz, path=feature_root)
+                dumper._dump_features(batch, bsz, path=node_feature_dir)
             del batch
             gc.collect()
             if torch.cuda.is_available():
@@ -110,8 +112,6 @@ def main_worker(fabric: Fabric, args):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
             torch.cuda.synchronize()
-
-    # No merge step needed anymore.
 
     # Stage 2: compute edge features
     edge_hparams = {
@@ -126,8 +126,14 @@ def main_worker(fabric: Fabric, args):
     }
     dumper = FeatureDumper(edge_hparams, device=fabric.local_rank)
     dumper.setup()
+    edge_dir = os.path.join(feature_root, rank_dir)
+    os.makedirs(edge_dir, exist_ok=True)
+    dataset_load_path = node_feature_dir if not args.load_node_features else feature_root
     dataset = _build_dataset(
-        args, load_features=feature_root, skip_edge_features=False, load_node_features_only=True
+        args,
+        load_features=dataset_load_path,
+        skip_edge_features=False,
+        load_node_features_only=True,
     )
     sampler = DistributedSampler(
         dataset,
@@ -139,7 +145,6 @@ def main_worker(fabric: Fabric, args):
         dataset, batch_size=1, sampler=sampler, collate_fn=dataset.collate_fn
     )
     loader = fabric.setup_dataloaders(loader)
-    edge_dir = feature_root  # dump edges directly to final dirs
     for batch in tqdm(loader, desc="Edges"):
         with torch.no_grad():
             batch = dumper.encode_features(batch)
@@ -151,8 +156,26 @@ def main_worker(fabric: Fabric, args):
             torch.cuda.empty_cache()
     del loader, dataset, dumper
     gc.collect()
+
+    fabric.barrier()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+
+    if fabric.global_rank == 0:
+        for r in range(fabric.world_size):
+            r_path = os.path.join(feature_root, str(r))
+            if not os.path.isdir(r_path):
+                continue
+            for item in os.listdir(r_path):
+                src = os.path.join(r_path, item)
+                dst = os.path.join(feature_root, item)
+                if os.path.isdir(src):
+                    os.makedirs(dst, exist_ok=True)
+                    for f in os.listdir(src):
+                        shutil.move(os.path.join(src, f), os.path.join(dst, f))
+                else:
+                    shutil.move(src, dst)
+            shutil.rmtree(r_path)
 
     fabric.barrier()
 


### PR DESCRIPTION
## Summary
- Write node and edge features to rank-specific subdirectories to avoid collisions
- After processing, clear VRAM, move each rank's outputs into the final directory, and sync all ranks

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689601ffa6508320815393581e274ddd