### PR TITLE
Batch CLIP/BLIP encodes to reduce VRAM spikes

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -60,6 +60,12 @@ def _parse_args():
     parser.add_argument("--scales", type=int, default=3)
     parser.add_argument("--max_nodes", type=int, default=1000)
     parser.add_argument("--max_edges", type=int, default=2000)
+    parser.add_argument("--clip_batch_size", type=int, default=64,
+                        help="Micro-batch size for CLIP/OpenSeg image encodes")
+    parser.add_argument("--blip_batch_size", type=int, default=32,
+                        help="Micro-batch size for BLIP image encodes")
+    parser.add_argument("--amp", action="store_true",
+                        help="Enable torch.cuda.amp autocast during encodes")
     parser.add_argument("--out_dir", default=None, help="directory to store features")
     parser.add_argument(
         "--load_node_features",
@@ -86,6 +92,11 @@ def main_worker(fabric: Fabric, args):
             "skip_edge_features": True,
             "max_nodes": args.max_nodes,
             "max_edges": args.max_edges,
+            "clip_batch_size": args.clip_batch_size,
+            "blip_batch_size": args.blip_batch_size,
+            "amp": args.amp,
+            "top_k_frames": args.top_k_frames,
+            "scales": args.scales,
         }
         dumper = FeatureDumper(node_hparams, device=fabric.local_rank)
         dumper.setup()
@@ -146,6 +157,11 @@ def main_worker(fabric: Fabric, args):
         "max_nodes": args.max_nodes,
         "max_edges": args.max_edges,
         "blip": True,
+        "clip_batch_size": args.clip_batch_size,
+        "blip_batch_size": args.blip_batch_size,
+        "amp": args.amp,
+        "top_k_frames": args.top_k_frames,
+        "scales": args.scales,
     }
     dumper = FeatureDumper(edge_hparams, device=fabric.local_rank)
     dumper.setup()


### PR DESCRIPTION
## Summary
- add CLI flags for CLIP/BLIP batch sizes and AMP in feature precomputation runner
- pass batching options to node and edge feature hparams
- chunk CLIP image encodes with optional AMP to avoid OOM

## Testing
- `python -m pytest -q`
- `python -m py_compile open3dsg/scripts/precompute_2d_features.py open3dsg/models/sgpn.py`


------
https://chatgpt.com/codex/tasks/task_e_689b55cf138c8320979f9d3da4882a3b