### PR TITLE
Track global point clouds and source files in MySet preprocessing

### DIFF
--- a/open3dsg/data/open_dataset.py
+++ b/open3dsg/data/open_dataset.py
@@ -120,6 +120,8 @@ class DataDict:
         self.objects_cat = np.array(data_dict["objects_cat"]).astype(np.uint8)
         self.objects_num = np.array(data_dict["objects_num"]).astype(np.int16)
         self.objects_pcl = np.array(data_dict["objects_pcl"]).astype(np.float32)
+        if "objects_pcl_glob" in data_dict:
+            self.objects_pcl_glob = np.array(data_dict["objects_pcl_glob"]).astype(np.float32)
         self.objects_center = np.array(data_dict["objects_center"]).astype(np.float32)
         self.objects_scale = np.array(data_dict["objects_scale"]).astype(np.float32)
         self.predicate_cat = np.array(data_dict["predicate_cat"]).astype(np.uint8)
@@ -140,6 +142,7 @@ class DataDict:
         self.rel2frame_mask = data_dict['rel2frame_mask']
         self.scene_id = data_dict["scene_id"]
         self.id2name = data_dict['id2name']
+        self.objects_file = data_dict.get("objects_file", [])
 
 
 def _load_data_tqdm(shared_list, relationship):
@@ -716,6 +719,13 @@ class Open2D3DSGDataset(Dataset):
         padding_width = ((0, self.max_objs - data_dict["objects_pcl"].shape[0]), (0, 0), (0, 0))
         data_dict["objects_pcl"] = np.pad(data_dict["objects_pcl"], padding_width, mode='constant')
         data_dict["objects_pcl"] = data_dict["objects_pcl"].astype(np.float32)
+
+        if "objects_pcl_glob" in data_dict and data_dict["objects_pcl_glob"].size > 0:
+            padding_width = ((0, self.max_objs - data_dict["objects_pcl_glob"].shape[0]), (0, 0), (0, 0))
+            data_dict["objects_pcl_glob"] = np.pad(data_dict["objects_pcl_glob"], padding_width, mode='constant')
+            data_dict["objects_pcl_glob"] = data_dict["objects_pcl_glob"].astype(np.float32)
+        else:
+            data_dict["objects_pcl_glob"] = np.zeros_like(data_dict["objects_pcl"])
 
         padding_width = ((0, self.max_objs - data_dict["objects_center"].shape[0]), (0, 0))
         data_dict["objects_center"] = np.pad(data_dict["objects_center"], padding_width, mode='constant', constant_values=0)

--- a/open3dsg/data/preprocess_myset.py
+++ b/open3dsg/data/preprocess_myset.py
@@ -69,6 +69,8 @@ def main():
 
         inst_meta = []
         objects_pcl = []
+        objects_pcl_glob = []
+        objects_file = []
         objects_num = []
         objects_center = []
         objects_scale = []
@@ -85,6 +87,8 @@ def main():
             padded = np.zeros((OBJ_SAMPLE, pcl.shape[1]), dtype=pcl.dtype)
             padded[:pcl.shape[0]] = pcl
             objects_pcl.append(padded)
+            objects_pcl_glob.append(padded)
+            objects_file.append(node["file"])
             objects_num.append(min(pcl.shape[0], OBJ_SAMPLE))
             aabb_min = np.array(node["aabb"][0])
             aabb_max = np.array(node["aabb"][1])
@@ -202,7 +206,8 @@ def main():
             "objects_cat": [0] * len(objects_id),
             "objects_num": objects_num,
             "objects_pcl": [p.tolist() for p in objects_pcl],
-            "objects_pcl_glob": [],
+            "objects_pcl_glob": [p.tolist() for p in objects_pcl_glob],
+            "objects_file": objects_file,
             "objects_center": objects_center,
             "objects_scale": objects_scale,
             "predicate_cat": predicate_cat,


### PR DESCRIPTION
## Summary
- Capture original object coordinates and file paths when preprocessing MySet scenes
- Include `objects_pcl_glob` and `objects_file` in saved graph dictionaries
- Loaders pad global point clouds and expose object file paths for downstream tasks

## Testing
- `python -m py_compile open3dsg/data/preprocess_myset.py open3dsg/data/open_dataset.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb43c99c48320abae4bde837bbad1