### PR TITLE
Handle image subfolders for frame association

### DIFF
--- a/open3dsg/data/get_object_frame_myset.py
+++ b/open3dsg/data/get_object_frame_myset.py
@@ -236,7 +236,7 @@ def main():
         inst_paths = sorted((scan / "mask/vis_instances").glob("inst_*.ply"))
         inst_pts = [np.asarray(o3d.io.read_point_cloud(str(p)).points) for p in inst_paths]
 
-        img_files = sorted(scan.glob("image_*.*"))
+        img_files = sorted((scan / "images").glob("*.*"))
         object2frame = {}
 
         for inst_idx, pts in enumerate(inst_pts):
@@ -276,9 +276,15 @@ def main():
                         axis=1,
                     ).astype(np.uint16)
                 scores.append((idx, vis))
-                # store the frame file name instead of numeric index so the
-                # dataset loader can directly resolve the image path
-                details[idx] = (img_path.name, pix_cnt, vis, bbox, pix_ids)
+                # store path relative to the scan directory so the dataset loader
+                # can resolve images residing in subfolders
+                details[idx] = (
+                    str(img_path.relative_to(scan)),
+                    pix_cnt,
+                    vis,
+                    bbox,
+                    pix_ids,
+                )
             top = [i for i, _ in sorted(scores, key=lambda x: -x[1])[: args.top_k]]
             object2frame[int(inst_idx)] = [details[i] for i in top if i in details]
 

--- a/open3dsg/data/open_dataset.py
+++ b/open3dsg/data/open_dataset.py
@@ -113,6 +113,13 @@ def read_class(path):
 clip_scales = [1.0, 1.5, 1.2, 2.0, 2.5, 1.8, 2.2, 2.8]  # possible clip scales order by diversty
 
 
+def _resolve_r3scan_frame(scene_id, frame):
+    base = os.path.join(CONF.PATH.R3SCAN_RAW, scene_id)
+    if os.path.sep in frame:
+        return os.path.join(base, frame)
+    return os.path.join(base, "sequence", frame)
+
+
 class DataDict:
     def __init__(self, data_dict):
         self.scan_id = data_dict["scan_id"]
@@ -316,7 +323,7 @@ class Open2D3DSGDataset(Dataset):
             if dataset == 'scannet':
                 imgs = [Image.open(os.path.join(CONF.PATH.SCANNET_RAW, "scannet_2d", scene_id, "color", s[1])) for s in selected]
             else:
-                imgs = [Image.open(os.path.join(CONF.PATH.R3SCAN_RAW, scene_id, 'sequence', s[1])).resize((224, 172)) for s in selected]
+                imgs = [Image.open(_resolve_r3scan_frame(scene_id, s[1])).resize((224, 172)) for s in selected]
 
             cropped_imgs = [img.crop(scale_bbox(s[2], sc, img)) for img, s in zip(imgs, selected) for sc in clip_scales[:scales]]
             if dataset == '3rscan':
@@ -386,7 +393,7 @@ class Open2D3DSGDataset(Dataset):
                 imgs = [np.asarray(Image.open(os.path.join(CONF.PATH.SCANNET_RAW, "scannet_2d", scene_id, "color", s[1]))
                                   .resize((blank_img_dim[1], blank_img_dim[0]))) for s in selected]
             else:
-                imgs = [np.asarray(Image.open(os.path.join(CONF.PATH.R3SCAN_RAW, scene_id, 'sequence', s[1]))
+                imgs = [np.asarray(Image.open(_resolve_r3scan_frame(scene_id, s[1]))
                                   .rotate(-90, expand=True)
                                   .resize((blank_img_dim[1], blank_img_dim[0]))) for s in selected]
             pixel_ids_img = [s[2] for s in selected]
@@ -462,7 +469,7 @@ class Open2D3DSGDataset(Dataset):
             if dataset == 'scannet':
                 imgs = [Image.open(os.path.join(CONF.PATH.SCANNET_RAW, "scannet_2d", scene_id, "color", s[1])) for s in selected]
             else:
-                imgs = [Image.open(os.path.join(CONF.PATH.R3SCAN_RAW, scene_id, 'sequence', s[1])).resize((224, 172)) for s in selected]
+                imgs = [Image.open(_resolve_r3scan_frame(scene_id, s[1])).resize((224, 172)) for s in selected]
 
             cropped_imgs = [img.crop(scale_bbox(enclosing_bbox(s[2], s[3]), 1+(sc-1)/2, img))
                             for img, s in zip(imgs, selected) for sc in clip_scales[:scales]]
@@ -537,7 +544,7 @@ class Open2D3DSGDataset(Dataset):
             if dataset == 'scannet':
                 imgs = [Image.open(os.path.join(CONF.PATH.SCANNET_RAW, "scannet_2d", scene_id, "color", s[1])) for s in selected]
             else:
-                imgs = [Image.open(os.path.join(CONF.PATH.R3SCAN_RAW, scene_id, 'sequence', s[1])) for s in selected]
+                imgs = [Image.open(_resolve_r3scan_frame(scene_id, s[1])) for s in selected]
             rel2frame_mask[list(rel2frame.keys())[i]] = len(imgs)
 
             imgs = [img.crop(scale_bbox(enclosing_bbox(s[2], s[3]), 1+(sc-1)/2, img))


### PR DESCRIPTION
## Summary
- Load frame images from an `images` subdirectory and store paths relative to each scan
- Resolve relative frame paths in dataset loader via `_resolve_r3scan_frame`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a44a9a2b7c83208f1b06896d500f41