### PR TITLE
Report skipped objects during 2D feature preprocessing

### DIFF
--- a/open3dsg/scripts/precompute_2d_features.py
+++ b/open3dsg/scripts/precompute_2d_features.py
@@ -149,6 +149,9 @@ def main_worker(fabric: Fabric, args):
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+        print(
+            f"Skipped {dataset.skipped_objects}/{dataset.total_objects} objects with no frame associations"
+        )
         del loader, dataset, dumper
         gc.collect()
         if torch.cuda.is_available():
@@ -205,6 +208,9 @@ def main_worker(fabric: Fabric, args):
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+    print(
+        f"Skipped {dataset.skipped_objects}/{dataset.total_objects} objects with no frame associations"
+    )
     del loader, dataset, dumper
     gc.collect()
 


### PR DESCRIPTION
## Summary
- Print counts of objects lacking frame associations after node feature computation
- Show the same skipped-object summary after edge feature extraction

## Testing
- `python -m py_compile open3dsg/scripts/precompute_2d_features.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a46c1501d083209ba14d86b4373d54