### PR TITLE
Fix blip_images batching to preserve relation dimension

### DIFF
--- a/open3dsg/data/open_dataset.py
+++ b/open3dsg/data/open_dataset.py
@@ -830,7 +830,11 @@ class Open2D3DSGDataset(Dataset):
             elif type(data[0][key]) is str:
                 data_dict[key] = [data[i][key] for i in range(len(data))]
             elif type(data[0][key]) is list:
-                data_dict[key] = [data[i][key] for i in range(len(data))]
+                if key == "blip_images":
+                    # Keep `[relation][frame]`; just unwrap batch
+                    data_dict[key] = data[0][key]
+                else:
+                    data_dict[key] = [d[key] for d in data]
             elif type(data[0][key]) is torch.Tensor:
                 data_dict[key] = torch.stack([data[i][key] for i in range(len(data))])
             elif type(data[0][key]) is np.ndarray:


### PR DESCRIPTION
## Summary
- Keep relation dimension for `blip_images` in `Open2D3DSGDataset.collate_fn`
- Simplify list handling to unwrap batch only for BLIP images

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6d6d6e483208a65e8c6a0be42e3