### PR TITLE
Fix dtype handling in query_node_features script

### DIFF
--- a/open3dsg/scripts/query_node_features.py
+++ b/open3dsg/scripts/query_node_features.py
@@ -82,7 +82,7 @@ def load_embeddings(feature_dir: str, scene_id: str) -> tuple[torch.Tensor, torc
     embeddings = torch.load(emb_path, map_location="cpu")
     valids = torch.load(valid_path, map_location="cpu").bool()
     valid_idx = torch.nonzero(valids, as_tuple=False).squeeze(1)
-    embeddings = embeddings[valid_idx]
+    embeddings = embeddings[valid_idx].float()
     model_name = obj_dir.split("export_obj_clip_emb_clip_")[1]
     return embeddings, valid_idx, model_name
 
@@ -129,7 +129,7 @@ def assign_colors(n: int) -> np.ndarray:
 def main() -> None:
     args = parse_args()
     embeddings, valid_idx, model_name = load_embeddings(args.features, args.scene)
-    text_emb = encode_text(args.word, model_name)
+    text_emb = encode_text(args.word, model_name).to(embeddings.dtype)
     embeddings = torch.nn.functional.normalize(embeddings, dim=1)
     text_emb = torch.nn.functional.normalize(text_emb, dim=1)
     sims = (embeddings @ text_emb.t()).squeeze(1)


### PR DESCRIPTION
## Summary
- cast filtered node embeddings to float32
- align text embedding dtype with node embeddings before normalization

## Testing
- `pytest`
- `python -m py_compile open3dsg/scripts/query_node_features.py`
- `PYTHONPATH=. python open3dsg/scripts/query_node_features.py --features tmp_features --graph tmp_graph.pkl --scene scene1 --word chair --topk 2 --out_ply tmp_out.ply --log tmp_log.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a5cb904274832093d915d131951cef