### PR TITLE
Add instance mask visualization utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ python open3dsg/scripts/reconstruct_pointcloud.py --graph <data_dict.pkl> --out 
 
 The script expects the graph dictionaries produced by [open3dsg/data/preprocess_scannet.py](open3dsg/data/preprocess_scannet.py) or [open3dsg/data/preprocess_3rscan.py](open3dsg/data/preprocess_3rscan.py). The output format is inferred from the `--out` extension (`.ply` or `.npz`).
 
+## Visualize Instance Masks
+
+Overlay projected pixel indices from `*_object2frame.pkl` files onto their
+corresponding RGB frames:
+
+```bash
+python open3dsg/scripts/visualize_instance_masks.py --scan_dir <scan_dir> \
+    --object2frame <scan_id>_object2frame.pkl --out vis --top_k 3
+```
+
+This writes files like `inst_12_frame_0.png` to the output directory.
+
 ### Model Downloads
 
 Download the [OpenSeg Checkpoint](https://github.com/tensorflow/tpu/tree/master/models/official/detection/projects/openseg), [BLIP2 Positional Embedding](https://drive.google.com/file/d/1BfvxB6eo3XksE6AfMUgoBHwzVYce1ed1/view?usp=sharing) & pre-trained [PointNet/PointNet2 weights](https://drive.google.com/drive/folders/1PrnJVMpJVVh4MAV4yPRuRByhBu-DuXwH?usp=sharing) and put them the checkpoints directory selected in the config file.

--- a/open3dsg/scripts/visualize_instance_masks.py
+++ b/open3dsg/scripts/visualize_instance_masks.py
@@ -1,0 +1,92 @@
+"""Visualise 2D instance masks on RGB frames.
+
+This helper reads ``*_object2frame.pkl`` files produced by
+:mod:`open3dsg.data.get_object_frame_myset` and saves overlays of the
+stored pixel indices onto their corresponding images.
+
+Example
+-------
+```bash
+python open3dsg/scripts/visualize_instance_masks.py \
+    --scan_dir path/to/scan \
+    --object2frame scan_id_object2frame.pkl \
+    --out masks --top_k 3
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from PIL import Image
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Overlay instance masks on their corresponding RGB frames",
+    )
+    parser.add_argument("--scan_dir", required=True, help="directory with RGB images")
+    parser.add_argument(
+        "--object2frame",
+        required=True,
+        help="pickle file mapping instances to frame information",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="output directory for visualisations",
+    )
+    parser.add_argument(
+        "--top_k", type=int, default=None, help="limit frames per instance to TOP_K",
+    )
+    return parser.parse_args()
+
+
+def load_mapping(path: str | Path) -> dict:
+    with open(path, "rb") as fh:
+        return pickle.load(fh)
+
+
+def iter_frames(frames: Iterable, top_k: int | None) -> Iterable[tuple[int, tuple]]:
+    if top_k is not None:
+        frames = frames[:top_k]
+    for idx, entry in enumerate(frames):
+        yield idx, entry
+
+
+def overlay_mask(image: Image.Image, pix_ids: np.ndarray) -> Image.Image:
+    """Return ``image`` with ``pix_ids`` overlayed in red."""
+
+    mask = np.zeros((240, 320), dtype=np.uint8)
+    if pix_ids.size:
+        mask[pix_ids[:, 0], pix_ids[:, 1]] = 1
+    rgba = np.zeros((240, 320, 4), dtype=np.uint8)
+    rgba[..., 0] = 255  # red
+    rgba[..., 3] = 128  # alpha
+    overlay = Image.fromarray(rgba * mask[..., None], mode="RGBA")
+    return Image.alpha_composite(image.convert("RGBA"), overlay)
+
+
+def main() -> None:
+    args = parse_args()
+    obj2frame = load_mapping(args.object2frame)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for inst_id, frames in obj2frame.items():
+        for frame_idx, (rel_path, _pix_cnt, _vis, _bbox, pix_ids) in iter_frames(
+            frames, args.top_k
+        ):
+            img = Image.open(Path(args.scan_dir) / rel_path).convert("RGB")
+            img = img.resize((320, 240))
+            blended = overlay_mask(img, np.asarray(pix_ids))
+            out_file = out_dir / f"inst_{inst_id}_frame_{frame_idx}.png"
+            blended.save(out_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `visualize_instance_masks.py` to overlay pix_ids onto RGB frames
- document visualization script usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d6077dd08320b47efc7b1f605673