### PR TITLE
Fix instance mask naming to avoid overwrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python open3dsg/scripts/visualize_instance_masks.py --scan_dir <scan_dir> \
     --object2frame <scan_id>_object2frame.pkl --out vis --top_k 3
 ```
 
-This writes files like `inst_12_frame_0.png` to the output directory.
+This writes files like `42.png` to the output directory.
 
 ### Model Downloads
 

--- a/open3dsg/scripts/visualize_instance_masks.py
+++ b/open3dsg/scripts/visualize_instance_masks.py
@@ -84,8 +84,9 @@ def main() -> None:
             img = Image.open(Path(args.scan_dir) / rel_path).convert("RGB")
             img = img.resize((320, 240))
             blended = overlay_mask(img, np.asarray(pix_ids))
-            out_file = out_dir / f"inst_{inst_id}_frame_{frame_idx}.png"
+            out_file = out_dir / f"{inst_id}.png"
             blended.save(out_file)
+            break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Save instance mask overlays as `<inst_id>.png`
- Stop after the first frame per instance to avoid overwrites
- Document new filename format in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5db305bb08320a630fd6fd654a850