### PR TITLE
Add script to find missing object frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ python scripts/save_frame_projections.py --scan_dir <scan_dir> --instance <inst.
 The command writes bounding boxes onto each frame and generates a
 `frames.json` file sorted by visibility.
 
+## Find Missing Object Frames
+
+List object IDs without frame associations in the preprocessed dataset:
+
+```bash
+python scripts/find_missing_obj_frames.py
+```
+
+Use `--out results.json` to save the output instead of printing it.
+
 ### Model Downloads
 
 Download the [OpenSeg Checkpoint](https://github.com/tensorflow/tpu/tree/master/models/official/detection/projects/openseg), [BLIP2 Positional Embedding](https://drive.google.com/file/d/1BfvxB6eo3XksE6AfMUgoBHwzVYce1ed1/view?usp=sharing) & pre-trained [PointNet/PointNet2 weights](https://drive.google.com/drive/folders/1PrnJVMpJVVh4MAV4yPRuRByhBu-DuXwH?usp=sharing) and put them the checkpoints directory selected in the config file.

--- a/scripts/find_missing_obj_frames.py
+++ b/scripts/find_missing_obj_frames.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""List objects without frame associations in preprocessed pickles."""
+
+import argparse
+import json
+import pickle
+from pathlib import Path
+
+from open3dsg.config.config import CONF
+
+
+def find_missing(root: Path):
+    """Return mapping of pickle file to missing object ids."""
+    missing = {}
+    for pkl_path in root.rglob("*_object2frame.pkl"):
+        with open(pkl_path, "rb") as fh:
+            obj2frame = pickle.load(fh)
+        empty = [oid for oid, frames in obj2frame.items() if not frames]
+        if empty:
+            missing[pkl_path] = empty
+    return missing
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out",
+        type=Path,
+        help="optional file to save the results as JSON",
+    )
+    args = ap.parse_args()
+
+    root = Path(CONF.PATH.MYSET_PREPROC_OUT)
+    missing = find_missing(root)
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            json.dump({str(k): v for k, v in missing.items()}, fh, indent=2)
+    else:
+        for pkl_path, ids in missing.items():
+            print(pkl_path)
+            for oid in ids:
+                print(f"  {oid}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utility to scan preprocessed outputs and report objects without frame associations
- document new script usage in README

## Testing
- `pip install numpy`
- `pip install easydict`
- `pytest`
- `PYTHONPATH=. python scripts/find_missing_obj_frames.py`

------
https://chatgpt.com/codex/tasks/task_e_68a713edf1c48320b7e60e05bfcd28a2