### PR TITLE
Add SAM feature dumper and integrate with pipeline

### DIFF
--- a/open3dsg/scripts/dump_features_two_step_sam.py
+++ b/open3dsg/scripts/dump_features_two_step_sam.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2024 Robert Bosch GmbH
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Dump CLIP features in two stages.
+
+This script spawns one worker per available GPU using
+``torch.multiprocessing.spawn``. Simply run:
+
+    python open3dsg/scripts/dump_features_two_step_sam.py --stage nodes ...
+    python open3dsg/scripts/dump_features_two_step_sam.py --stage edges --load_node_features <dir> ...
+"""
+
+import argparse
+import json
+import os
+import random
+from datetime import datetime
+import gc
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+from tqdm import tqdm
+
+import shutil
+
+from open3dsg.config.config import CONF
+from open3dsg.data.open_dataset import Open2D3DSGDataset
+from open3dsg.scripts.feature_dumper import FeatureDumper
+from open3dsg.scripts.feature_dumper_sam import FeatureDumper as FeatureDumperSAM
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    # system params
+    parser.add_argument('--gpus', type=int, default=-1)
+    parser.add_argument("--workers", type=int, default=8, help="number of workers per gpu")
+    parser.add_argument("--seed", type=int, default=42, help="random seed")
+    parser.add_argument("--run_name", type=str, help="dir name for tensorboard and checkpoints")
+    parser.add_argument('--mixed_precision', action="store_true", help="Use mixed precision training")
+
+    # optimizer params (unused but kept for compatibility)
+    parser.add_argument('--accumulate_grad_batches', type=int, default=1)
+    parser.add_argument("--epochs", type=int, help="number of epochs", default=50)
+    parser.add_argument("--batch_size", type=int, help="batch size", default=1)
+    parser.add_argument("--lr", type=float, help="learning rate", default=1e-4)
+    parser.add_argument("--lr_scheduler", type=str, default="reduce", help="lr_scheduler, options [cyclic, reduce]")
+    parser.add_argument("--wd", type=float, help="weight decay", default=1e-2)
+    parser.add_argument("--bn_momentum", type=float, default=0.9, help="Initial batch norm momentum [default: 0.9]")
+    parser.add_argument("--bn_decay", type=float, default=0.5,   help="Batch norm momentum decay gamma [default: 0.5]")
+    parser.add_argument("--decay_step", type=float, default=1e5, help="Learning rate decay step [default: 20]",)
+
+    parser.add_argument('--w_obj', type=float, default=1.0)
+    parser.add_argument('--w_rel', type=float, default=1.0)
+
+    # model params
+    parser.add_argument('--use_rgb', action="store_true", help="Whether to use rgb features as input the the point net")
+    parser.add_argument("--gnn_layers", type=int, default=4, help="number of gnn layers")
+    parser.add_argument('--graph_backbone', default="message", nargs='?',
+                        choices=['message', 'attention', 'transformer', 'mlp'])
+    parser.add_argument('--gconv_dim', type=int, default=512, help='embedding dim for point features')
+    parser.add_argument('--hidden_dim', type=int, default=1024, help='hidden dim for graph_convs')
+    parser.add_argument('--max_nodes', type=int, default=100, help='max number of nodes in the graph')
+    parser.add_argument('--max_edges', type=int, default=800,
+                        help='max number of edges in the graph. Should correspond to n*(n-1) nodes')
+
+    # data params
+    parser.add_argument('--dataset', default='scannet', help="['scannet']")
+    parser.add_argument('--mini_dataset', action='store_true',
+                        help="only load a tiny fraction of data for faster debugging")
+    parser.add_argument('--augment', action="store_true",
+                        help="use basic pcl augmentations that do not collide with scene graph properties")
+    parser.add_argument("--top_k_frames", type=int, default=5, help="number of frames to consider for each instance")
+    parser.add_argument("--scales", type=int, default=3, help="number of scales for each selected image")
+    parser.add_argument('--dump_features', action="store_true", help="precompute 2d features and dump to disk")
+    parser.add_argument('--load_features', default=None, help="path to precomputed 2d features")
+    parser.add_argument('--skip_edge_features', action='store_true',
+                        help='Skip relation image feature computation')
+
+    # model variations params
+    parser.add_argument('--clip_model', default="SAM", type=str,
+                        choices=['ViT-B/32', 'ViT-B/16', 'ViT-L/14', 'ViT-L/14@336px', 'OpenSeg', 'SAM'])
+    parser.add_argument('--node_model', default='ViT-L/14@336px', type=str,
+                        choices=['ViT-B/32', 'ViT-B/16', 'ViT-L/14', 'ViT-L/14@336px'])
+    parser.add_argument('--edge_model', default=None, type=str,
+                        choices=['ViT-B/32', 'ViT-B/16', 'ViT-L/14', 'ViT-L/14@336px'])
+    parser.add_argument('--blip', action="store_true", help="Use blip for relation prediction")
+    parser.add_argument('--avg_blip_emb', action='store_true', help="Average the blip embeddings across patches")
+    parser.add_argument('--blip_proj_layers', type=int, default=3,
+                        help="Number of projection layers to match blip embedding")
+    parser.add_argument('--blip_batch_size', type=int, default=32, help='Batch size for BLIP image encoding')
+    parser.add_argument('--llava', action="store_true", help="Use llava for relation prediction")
+    parser.add_argument('--avg_llava_emb', action="store_true", help="Average the llava embeddings across patches")
+    parser.add_argument('--pointnet2', action="store_true",
+                        help="Use pointnet++ for feature extraction. However RGB input not working")
+    parser.add_argument("--clean_pointnet", action="store_true",
+                        help="standard pretrained pointnet for feature extraction")
+    parser.add_argument('--supervised_edges', action="store_true", help="Train edges supervised instead of open-vocab")
+
+    # eval params (unused but kept for compatibility)
+    parser.add_argument("--test", action="store_true", help="test the model")
+    parser.add_argument("--checkpoint", type=str, help="Specify the checkpoint root", default=None)
+    parser.add_argument('--weight_2d', type=float, default=0.5, help="2d-3d feature fusion weight")
+    parser.add_argument('--n_beams', type=int, default=5, help="number of beams for beam search in LLM output")
+    parser.add_argument('--gt_objects', action="store_true", help="Use GT objects for predicate prediction")
+    parser.add_argument('--vis_graphs', action="store_true", help="save graph predictions to disk")
+    parser.add_argument('--predict_from_2d', action="store_true", help="predict only using 2d models")
+    parser.add_argument('--quick_eval', action='store_true', help="only eval on a few samples")
+    parser.add_argument('--object_context', action="store_true", help="prompt clip with: A [object] in a scene")
+    parser.add_argument('--update_hparams', action="store_true", help="update hparams from checkpoint")
+    parser.add_argument('--manual_mapping', action="store_true", help="Manually map some known predicates to GT")
+
+    # two step params
+    parser.add_argument('--stage', required=True, choices=['nodes', 'edges'])
+    parser.add_argument('--load_node_features', type=str,
+                        help='directory containing precomputed node features')
+
+    return parser.parse_args()
+
+
+def build_dataset(args, load_features, skip_edge_features, load_node_features_only=False):
+    def load_scan(base_path, file_path):
+        return json.load(open(os.path.join(base_path, file_path)))['scans']
+
+    dataset_name = args.dataset.lower()
+    if dataset_name == 'myset':
+        base_path = CONF.PATH.MYSET_GRAPHS_OUT
+    else:
+        base_path = CONF.PATH.SCANNET
+
+    relationships_scannet = load_scan(base_path, "subgraphs/relationships_train.json")
+
+    if args.clip_model in ('OpenSeg', 'SAM'):
+        img_dim = 336 if args.node_model == 'ViT-L/14@336px' else 224
+    else:
+        img_dim = 336 if args.clip_model == 'ViT-L/14@336px' else 224
+
+    rel_img_dim = img_dim
+    if args.edge_model:
+        rel_img_dim = 336 if args.edge_model == 'ViT-L/14@336px' else 224
+
+    dataset = Open2D3DSGDataset(
+        relationships_R3SCAN=None,
+        relationships_scannet=relationships_scannet,
+        openseg=args.clip_model in ('OpenSeg', 'SAM'),
+        img_dim=img_dim,
+        rel_img_dim=rel_img_dim,
+        top_k_frames=args.top_k_frames,
+        scales=args.scales,
+        mini=args.mini_dataset,
+        load_features=load_features,
+        blip=args.blip,
+        llava=args.llava,
+        max_objects=args.max_nodes,
+        max_rels=args.max_edges,
+        skip_edge_features=skip_edge_features,
+        load_node_features_only=load_node_features_only,
+    )
+    return dataset
+
+def worker(rank, world_size, args):
+    if torch.cuda.is_available():
+        torch.cuda.set_device(rank)
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    if world_size > 1:
+        dist.init_process_group(
+            backend, init_method="tcp://127.0.0.1:29500", rank=rank, world_size=world_size
+        )
+
+    torch.manual_seed(args.seed + rank)
+    np.random.seed(args.seed + rank)
+    random.seed(args.seed + rank)
+
+    hparams = vars(args).copy()
+    hparams["dump_features"] = True
+    hparams["load_features"] = None
+    if args.stage == "nodes":
+        hparams["skip_edge_features"] = True
+    else:
+        hparams["skip_edge_features"] = False
+        hparams["load_node_features_only"] = True
+
+    DumperClass = FeatureDumperSAM if args.clip_model == 'SAM' else FeatureDumper
+    module = DumperClass(hparams, device=rank)
+    module.clip_path = args.base_feature_dir
+    module.setup()
+    device = torch.device(f"cuda:{rank}" if torch.cuda.is_available() else "cpu")
+    if world_size > 1:
+        module.model = DDP(
+            module.model, device_ids=[rank] if torch.cuda.is_available() else None
+        )
+    module.model.eval()
+
+    if args.stage == "nodes":
+        dataset = build_dataset(args, None, True)
+    else:
+        dataset = build_dataset(
+            args, args.base_feature_dir, False, load_node_features_only=True
+        )
+
+    feature_dir = (
+        args.base_feature_dir
+        if world_size == 1
+        else os.path.join(args.base_feature_dir, f"rank{rank}")
+    )
+    os.makedirs(feature_dir, exist_ok=True)
+
+    sampler = DistributedSampler(
+        dataset, num_replicas=world_size, rank=rank, shuffle=False
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        sampler=sampler,
+        num_workers=args.workers,
+        collate_fn=dataset.collate_fn,
+    )
+
+    if rank == 0:
+        pbar = tqdm(total=len(sampler), desc="Processing scenes")
+    with torch.no_grad():
+        for data_dict in dataloader:
+            if "object_imgs" in data_dict:
+                data_dict["object_imgs"] = data_dict["object_imgs"].to(device)
+            if "relationship_imgs" in data_dict:
+                data_dict["relationship_imgs"] = data_dict["relationship_imgs"].to(device)
+            if "blip_images" in data_dict:
+                data_dict["blip_images"] = data_dict["blip_images"].to(device)
+
+            data_dict = module.encode_features(data_dict)
+
+            module._dump_features(
+                data_dict, data_dict["objects_id"].size(0), path=feature_dir
+            )
+            if rank == 0:
+                pbar.update(len(data_dict.get("scan_id", [])))
+
+            del data_dict
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    if rank == 0:
+        pbar.close()
+
+    if world_size > 1:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def main():
+    args = get_args()
+    world_size = args.gpus if args.gpus > 0 else torch.cuda.device_count()
+    world_size = max(1, world_size)
+
+    if args.stage == "nodes":
+        base_dir = os.path.join(
+            CONF.PATH.FEATURES,
+            f"clip_features_{datetime.now().strftime('%Y-%m-%d-%H-%M')}",
+        )
+    else:
+        if args.load_node_features is None:
+            raise ValueError("--load_node_features required for edges stage")
+        base_dir = args.load_node_features
+
+    args.base_feature_dir = base_dir
+
+    if world_size > 1:
+        mp.spawn(worker, nprocs=world_size, args=(world_size, args))
+        for r in range(world_size):
+            rank_dir = os.path.join(base_dir, f"rank{r}")
+            if not os.path.isdir(rank_dir):
+                continue
+            for root, _, files in os.walk(rank_dir):
+                rel_path = os.path.relpath(root, rank_dir)
+                dest_root = os.path.join(base_dir, rel_path) if rel_path != "." else base_dir
+                os.makedirs(dest_root, exist_ok=True)
+                for fname in files:
+                    src_file = os.path.join(root, fname)
+                    dst_file = os.path.join(dest_root, fname)
+                    if os.path.exists(dst_file):
+                        base, ext = os.path.splitext(fname)
+                        i = 1
+                        new_dst = dst_file
+                        while os.path.exists(new_dst):
+                            new_dst = os.path.join(dest_root, f"{base}_{i}{ext}")
+                            i += 1
+                        dst_file = new_dst
+                    shutil.move(src_file, dst_file)
+            shutil.rmtree(rank_dir)
+    else:
+        worker(0, 1, args)
+
+    print(f"Features saved to {base_dir}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/open3dsg/scripts/feature_dumper_sam.py
+++ b/open3dsg/scripts/feature_dumper_sam.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2024 Robert Bosch GmbH
+# SPDX-License-Identifier: AGPL-3.0
+
+import os
+from datetime import datetime
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import clip
+
+from open3dsg.models.clip_utils import encode_node_images_in_batches
+
+from open3dsg.config.config import CONF
+from open3dsg.models.sgpn_sam import SGPN as SGPN_SAM
+try:  # pragma: no cover - optional dependency
+    from segment_anything import SamPredictor, sam_model_registry
+except Exception:  # pragma: no cover - handled at runtime
+    SamPredictor = None
+    sam_model_registry = {}
+
+
+def inplace_relu(m):
+    classname = m.__class__.__name__
+    if classname.find('ReLU') != -1:
+        m.inplace = True
+
+
+class MinimalSGPN(SGPN_SAM):
+    """Lightweight wrapper exposing only the 2D encoders from :class:`SGPN_SAM`."""
+
+    def __init__(self, hparams):
+        # Skip heavy initialisation by avoiding ``SGPN_SAM.__init__``.
+        torch.nn.Module.__init__(self)
+        self.hparams = hparams
+
+        # Placeholders populated during setup.
+        self.CLIP = None
+        self.CLIP_NODE = None
+        self.CLIP_EDGE = None
+        self.OPENSEG = None
+        self.BLIP = None
+        self.LLaVA = None
+        self.PROCESSOR = None
+        self.blip_pos_encoding = None
+        self.sam_predictor = None
+
+    @torch.no_grad()
+    def blip_encode_images(self, rel_imgs, batch_size: int = 32):
+        device = next(self.parameters()).device
+        rel_shapes = [len(r) for r in rel_imgs]
+        flat_imgs = [img for rel in rel_imgs for img in rel]
+        rel_embeds = []
+        with torch.no_grad():
+            for i in range(0, len(flat_imgs), batch_size):
+                batch = flat_imgs[i : i + batch_size]
+                inputs = (
+                    self.PROCESSOR(images=batch, text=None, return_tensors="pt")
+                    .to(device)
+                )
+                rel_embeds.append(self.BLIP.embedd_image(inputs["pixel_values"]))
+                torch.cuda.empty_cache()
+
+        if not flat_imgs:
+            return torch.empty((len(rel_imgs), 0, 257, 1408), device=device)
+
+        rel_embeds = torch.cat(rel_embeds, dim=0)
+        token_dim, embed_dim = rel_embeds.shape[1:]
+        max_frames = max(rel_shapes) if rel_shapes else 0
+        rebuilt = rel_embeds.new_zeros((len(rel_shapes), max_frames, token_dim, embed_dim))
+        offset = 0
+        for idx, n in enumerate(rel_shapes):
+            rebuilt[idx, :n] = rel_embeds[offset : offset + n]
+            offset += n
+        return rebuilt
+
+
+class FeatureDumper:
+    """Utility class for precomputing 2D features without Lightning overhead."""
+
+    def __init__(self, hparams, device: int = 0):
+        self.hparams = hparams
+        self.hparams.setdefault("clip_model", "SAM")
+        self.hparams.setdefault("load_features", False)
+        self.hparams.setdefault("test", False)
+        self.device_index = device
+        # Only keep lightweight 2D encoders.
+        self.model = MinimalSGPN(self.hparams)
+
+        # default path for dumping node features when stage == 'nodes'
+        self.clip_path = os.path.join(
+            CONF.PATH.FEATURES,
+            f"clip_features_{datetime.now().strftime('%Y-%m-%d-%H-%M')}",
+        )
+
+    def setup(self):
+        """Load pretrained 2D models required for feature extraction."""
+        if self.hparams['clip_model'] == 'SAM':
+            self.model.CLIP = self.model.load_pretrained_clip_model(
+                target_model=self.model.CLIP, model=self.hparams.get('node_model', 'ViT-B/32')
+            )
+        elif self.hparams['clip_model'] == 'OpenSeg':
+            self.model.OPENSEG = self.model.load_pretrained_clip_model(
+                target_model=self.model.OPENSEG, model=self.hparams['clip_model']
+            )
+        else:
+            self.model.CLIP = self.model.load_pretrained_clip_model(
+                target_model=self.model.CLIP, model=self.hparams['clip_model']
+            )
+
+        if self.hparams.get('node_model'):
+            self.model.CLIP_NODE = self.model.load_pretrained_clip_model(
+                target_model=self.model.CLIP_NODE, model=self.hparams['node_model']
+            )
+        if self.hparams.get('edge_model'):
+            self.model.CLIP_EDGE = self.model.load_pretrained_clip_model(
+                target_model=self.model.CLIP_EDGE, model=self.hparams['edge_model']
+            )
+
+        if self.hparams.get('blip'):
+            if self.hparams.get('dump_features'):
+                self.model.load_pretrained_blipvision_model()
+            else:
+                self.model.load_pretrained_blip_model()
+        elif self.hparams.get('llava'):
+            self.model.load_pretrained_llava_model()
+
+        device = torch.device(
+            f"cuda:{self.device_index}" if torch.cuda.is_available() else "cpu"
+        )
+        self.model.to(device)
+
+        if self.hparams['clip_model'] == 'SAM':
+            if SamPredictor is None:
+                raise ImportError("segment_anything is required for SAM features")
+            sam_type = self.hparams.get("sam_model", "vit_h")
+            sam_ckpt = self.hparams.get(
+                "sam_checkpoint",
+                os.path.join(CONF.PATH.CHECKPOINTS, f"sam_{sam_type}.pth"),
+            )
+            sam = sam_model_registry[sam_type](checkpoint=sam_ckpt)
+            sam.to(device)
+            self.model.sam_predictor = SamPredictor(sam)
+
+    def encode_features(self, data_dict):
+        """Populate ``clip_obj_encoding`` and ``clip_rel_encoding`` using 2D encoders."""
+
+        device = next(self.model.parameters()).device
+        model = (
+            self.model.module
+            if isinstance(
+                self.model, torch.nn.parallel.DistributedDataParallel
+            )
+            else self.model
+        )
+
+        obj_imgs = data_dict.get('object_imgs')
+        rel_imgs = data_dict.get('relationship_imgs')
+        obj_raw_imgs = data_dict.get('object_raw_imgs')
+        obj_pixels = data_dict.get('object_pixels')
+        obj_nums = data_dict.get('objects_count')
+
+        if obj_raw_imgs is not None and torch.is_tensor(obj_raw_imgs):
+            obj_raw_imgs = obj_raw_imgs.to(device)
+
+        def _rel_imgs_empty(imgs):
+            return imgs is None or (
+                isinstance(imgs, list)
+                and (not imgs or sum(len(r) for r in imgs) == 0)
+            )
+
+        if self.hparams.get('blip') and _rel_imgs_empty(rel_imgs):
+            rel_imgs = data_dict.get("blip_images")
+            if (
+                isinstance(rel_imgs, list)
+                and len(rel_imgs) == 1
+                and isinstance(rel_imgs[0], list)
+            ):
+                rel_imgs = rel_imgs[0]
+
+        rel_imgs_empty = _rel_imgs_empty(rel_imgs)
+
+        clip_rel_feats = None
+
+        if self.hparams['clip_model'] == 'SAM' and obj_raw_imgs is not None:
+            clip_obj_feats, clip_rel_feats = model.sam_clip_encode_pixels(
+                obj_raw_imgs, obj_pixels, obj_nums, rel_imgs
+            )
+            data_dict['clip_obj_encoding'] = clip_obj_feats
+        elif self.hparams['clip_model'] == 'OpenSeg' and obj_raw_imgs is not None:
+            rel_input = rel_imgs if torch.is_tensor(rel_imgs) else None
+            if rel_input is None:
+                rel_input = torch.zeros(
+                    obj_raw_imgs.size(0), 1, 1, 3, obj_raw_imgs.size(-2), obj_raw_imgs.size(-1),
+                    device=obj_raw_imgs.device,
+                )
+            clip_obj_feats, clip_rel_feats = model.clip_encode_pixels(
+                obj_raw_imgs, obj_pixels, obj_nums, rel_input
+            )
+            data_dict['clip_obj_encoding'] = clip_obj_feats
+        elif obj_imgs is not None:
+            batch_size = int(self.hparams.get('clip_batch', self.hparams.get('clip_batch_size', 64)))
+            amp = bool(self.hparams.get('clip_amp', self.hparams.get('amp', True)))
+            sync_cuda = bool(self.hparams.get('sync_cuda', False))
+            if (
+                isinstance(rel_imgs, torch.Tensor)
+                and not self.hparams.get('skip_edge_features')
+                and not self.hparams.get('blip')
+                and not self.hparams.get('llava')
+            ):
+                enc_rel = model.CLIP_EDGE if self.hparams.get('edge_model') else model.CLIP
+                clip_rel_feats = encode_node_images_in_batches(
+                    rel_imgs, enc_rel, device, batch_size, amp=amp, sync_cuda=sync_cuda
+                )
+            enc_obj = model.CLIP_NODE if self.hparams.get('node_model') else model.CLIP
+            clip_obj_feats = encode_node_images_in_batches(
+                obj_imgs, enc_obj, device, batch_size, amp=amp, sync_cuda=sync_cuda
+            )
+            data_dict['clip_obj_encoding'] = clip_obj_feats
+        elif (
+            isinstance(rel_imgs, torch.Tensor)
+            and not self.hparams.get('blip')
+            and not self.hparams.get('llava')
+        ):
+            enc_rel = model.CLIP_EDGE if self.hparams.get('edge_model') else model.CLIP
+            clip_rel_feats = encode_node_images_in_batches(
+                rel_imgs,
+                enc_rel,
+                device,
+                batch_size=int(self.hparams.get('clip_batch', self.hparams.get('clip_batch_size', 64))),
+                amp=bool(self.hparams.get('clip_amp', self.hparams.get('amp', True))),
+                sync_cuda=bool(self.hparams.get('sync_cuda', False)),
+            )
+
+        if self.hparams.get('blip'):
+            if rel_imgs is not None and not rel_imgs_empty:
+                data_dict['clip_rel_encoding'] = model.blip_encode_images(
+                    rel_imgs, batch_size=self.hparams.get('blip_batch_size', self.hparams.get('blip_batch', 32))
+                )
+            else:
+                num_frames = self.hparams.get('top_k_frames', 1) * self.hparams.get('scales', 1)
+                data_dict['clip_rel_encoding'] = torch.empty(
+                    (0, num_frames, 257, 1408), device=device
+                )
+        elif self.hparams.get('llava') and rel_imgs is not None:
+            data_dict['clip_rel_encoding'] = model.llava_encode_images(rel_imgs)
+        elif clip_rel_feats is not None:
+            data_dict['clip_rel_encoding'] = clip_rel_feats
+
+        return data_dict
+
+    def _mask_features(self, data_dict, clip_obj_emb, clip_rel_emb, bidx, obj_count, rel_count):
+        obj_valids = None
+        clip_rel_emb_masked = None
+        if isinstance(clip_obj_emb, torch.Tensor):
+            mask_key = (
+                'obj2frame_raw_mask' if self.hparams['clip_model'] == 'OpenSeg' else 'obj2frame_mask'
+            )
+            has_mask = mask_key in data_dict
+            has_frame_dim = clip_obj_emb.dim() > 2
+
+            if has_mask and has_frame_dim:
+                clip_obj2frame_mask = data_dict[mask_key][bidx][:obj_count].to(
+                    clip_obj_emb.device
+                )
+                clip_obj_mask = (
+                    torch.arange(
+                        clip_obj_emb.size(1), device=clip_obj_emb.device
+                    ).unsqueeze(0)
+                    < clip_obj2frame_mask.unsqueeze(1)
+                )
+                clip_obj_emb[~clip_obj_mask] = np.nan
+                clip_obj_emb = torch.nanmean(clip_obj_emb, dim=1)
+                obj_valids = ~torch.isnan(clip_obj_emb).all(-1)
+            else:
+                obj_valids = ~torch.isnan(clip_obj_emb).all(-1)
+
+        if isinstance(clip_rel_emb, torch.Tensor):
+            clip_rel2frame_mask = data_dict['rel2frame_mask'][bidx][:rel_count].to(
+                clip_rel_emb.device
+            )
+            clip_rel_mask = (
+                torch.arange(
+                    clip_rel_emb.size(1), device=clip_rel_emb.device
+                ).unsqueeze(0)
+                < clip_rel2frame_mask.unsqueeze(1)
+            )
+            clip_rel_emb[~clip_rel_mask] = np.nan
+            clip_rel_emb = torch.nanmean(clip_rel_emb, dim=1)
+
+            clip_rel_emb_masked = torch.zeros_like(clip_rel_emb)
+            clip_rel_emb_masked[clip_rel2frame_mask > 0] = clip_rel_emb[clip_rel2frame_mask > 0]
+
+        return obj_valids, clip_obj_emb, clip_rel_emb_masked
+
+    def _dump_features(self, data_dict, batch_size, path=CONF.PATH.FEATURES):
+        def _atomic_save(tensor, final_path: str):
+            tmp_path = final_path + ".tmp"
+            torch.save(tensor, tmp_path)
+            os.replace(tmp_path, final_path)  # atomic on POSIX
+
+        for bidx in range(batch_size):
+            obj_count = int(data_dict['objects_count'][bidx].item())
+            rel_count = int(data_dict['predicate_count'][bidx].item())
+
+            clip_obj_emb = data_dict['clip_obj_encoding'][bidx][:obj_count]
+            clip_rel_emb = None
+            if (
+                not self.hparams.get('skip_edge_features')
+                and data_dict.get('clip_rel_encoding') is not None
+            ):
+                clip_rel_emb = data_dict['clip_rel_encoding'][bidx][:rel_count]
+
+            obj_valids, clip_obj_emb, clip_rel_emb_masked = self._mask_features(
+                data_dict, clip_obj_emb, clip_rel_emb, bidx, obj_count, rel_count
+            )
+
+            obj_clip_model = (
+                self.hparams['node_model']
+                if self.hparams.get('node_model') and self.hparams['clip_model'] != 'OpenSeg'
+                else self.hparams['clip_model']
+            )
+
+            obj_path = os.path.join(
+                path, 'export_obj_clip_emb_clip_' + obj_clip_model.replace('/', '-')
+            )
+            obj_valid_path = os.path.join(path, 'export_obj_clip_valids')
+            os.makedirs(obj_path, exist_ok=True)
+            os.makedirs(obj_valid_path, exist_ok=True)
+
+            _atomic_save(
+                clip_obj_emb.detach().cpu(),
+                os.path.join(obj_path, data_dict['scan_id'][bidx] + '.pt'),
+            )
+            _atomic_save(
+                obj_valids.detach().cpu(),
+                os.path.join(obj_valid_path, data_dict['scan_id'][bidx] + '.pt'),
+            )
+            if clip_rel_emb_masked is not None:
+                rel_clip_model = (
+                    self.hparams['edge_model']
+                    if self.hparams.get('edge_model')
+                    else self.hparams['clip_model']
+                )
+                if self.hparams.get('blip'):
+                    rel_clip_model = 'BLIP'
+                elif self.hparams.get('llava'):
+                    rel_clip_model = 'LLaVa'
+                rel_path = os.path.join(
+                    path, 'export_rel_clip_emb_clip_' + rel_clip_model.replace('/', '-')
+                )
+                os.makedirs(rel_path, exist_ok=True)
+                _atomic_save(
+                    clip_rel_emb_masked.detach().cpu(),
+                    os.path.join(rel_path, data_dict['scan_id'][bidx] + '.pt'),
+                )


### PR DESCRIPTION
## Summary
- Add `feature_dumper_sam.py` that loads SAM and SGPN_SAM and encodes features via `sam_clip_encode_pixels`
- Duplicate the two-step feature dumper as `dump_features_two_step_sam.py` (defaulting to SAM) and keep the original script unchanged
- Wire up conditional selection of `FeatureDumperSAM` when `--clip_model` is `SAM`

## Testing
- `pip install numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7978958cc83209016877ea6296d11