### PR TITLE
Add instance splitting tool based on pixel features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All projection utilities interpret camera coordinates as **y-up** and automatica
 ```bash
 python open3dsg/data/get_object_frame.py --mode [train/test] --dataset [R3SCAN/SCANNET]
 python -m open3dsg.data.merge_instance_masks --scan <scan_id> --dataset <R3SCAN/SCANNET> --masks_dir <path_to_2d_masks>
+python -m open3dsg.data.split_instance_masks --scan <scan_id> --dataset <R3SCAN/SCANNET> --eps 0.3 --min_samples 10
 ```
 
 We pre-process the data before the training for faster data processing in the training loop.

--- a/open3dsg/data/split_instance_masks.py
+++ b/open3dsg/data/split_instance_masks.py
@@ -1,0 +1,131 @@
+import argparse
+import os
+import pickle
+from pathlib import Path
+
+import numpy as np
+import cv2
+from sklearn.cluster import DBSCAN
+
+from open3dsg.config.config import CONF
+from open3dsg.data.get_object_frame import (
+    read_pointcloud_R3SCAN,
+    read_pointcloud_scannet,
+    read_scan_info_R3SCAN,
+    read_scan_info_scannet,
+    compute_mapping,
+)
+
+
+def aggregate_point_features(points, frame_indices, depths, extrinsics, intrinsic, images):
+    """Aggregate per-point RGB features across frames.
+
+    Parameters
+    ----------
+    points : ndarray (N,3)
+        3D coordinates of a single instance.
+    frame_indices : list[int]
+        Frames to aggregate over.
+    depths : ndarray (F,H*W)
+        Depth images for all frames as flattened arrays in millimetres.
+    extrinsics : ndarray (F,4,4)
+        Camera extrinsic matrices (world->camera).
+    intrinsic : ndarray (3,3)
+        Camera intrinsic matrix.
+    images : list or ndarray (F,H,W,3)
+        RGB images aligned with ``depths``.
+
+    Returns
+    -------
+    ndarray (N,3)
+        Averaged RGB feature for each point, normalized to [0,1].
+    """
+    if points.size == 0 or len(frame_indices) == 0:
+        return np.zeros((points.shape[0], 3), dtype=np.float32)
+
+    image_dim = np.array([images[0].shape[1], images[0].shape[0]])
+    feats = np.zeros((points.shape[0], 3), dtype=np.float32)
+    counts = np.zeros(points.shape[0], dtype=np.int32)
+
+    for f_idx in frame_indices:
+        depth = depths[f_idx].reshape(image_dim[::-1]) / 1000.0
+        mapping = compute_mapping(extrinsics[f_idx], points, depth, intrinsic, 0, 0.05, image_dim).T
+        vis = mapping[:, 2] == 1
+        if not np.any(vis):
+            continue
+        pix = mapping[vis, :2].astype(int)
+        pix[:, 0] = np.clip(pix[:, 0], 0, image_dim[1] - 1)
+        pix[:, 1] = np.clip(pix[:, 1], 0, image_dim[0] - 1)
+        colors = images[f_idx][pix[:, 0], pix[:, 1]].astype(np.float32) / 255.0
+        feats[vis] += colors
+        counts[vis] += 1
+
+    counts[counts == 0] = 1
+    feats /= counts[:, None]
+    return feats
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Split 3D instances using pixel features and DBSCAN")
+    parser.add_argument("--scan", required=True, help="scan id")
+    parser.add_argument("--dataset", required=True, choices=["R3SCAN", "SCANNET"], help="dataset name")
+    parser.add_argument("--eps", type=float, default=0.3, help="DBSCAN epsilon")
+    parser.add_argument("--min_samples", type=int, default=10, help="DBSCAN min samples")
+    args = parser.parse_args()
+
+    if args.dataset == "R3SCAN":
+        pc, inst = read_pointcloud_R3SCAN(args.scan)
+        depths, colors, extrinsics, intr_info, img_names = read_scan_info_R3SCAN(args.scan)
+        intrinsic = intr_info["m_intrinsic"]
+        views_dir = Path(CONF.PATH.R3SCAN) / "views"
+    else:
+        pc, _, inst = read_pointcloud_scannet(args.scan)
+        depths, colors, extrinsics, intr_info, img_names = read_scan_info_scannet(args.scan)
+        intrinsic = np.loadtxt(os.path.join(CONF.PATH.SCANNET_RAW2D, "intrinsics.txt"))
+        views_dir = Path(CONF.PATH.SCANNET) / "views"
+
+    obj2frame_file = views_dir / f"{args.scan}_object2image.pkl"
+    if not obj2frame_file.exists():
+        raise FileNotFoundError(f"{obj2frame_file} not found")
+    obj2frame = pickle.load(open(obj2frame_file, "rb"))
+
+    name_to_idx = {n: i for i, n in enumerate(img_names)}
+    new_labels = np.zeros(len(inst), dtype=int)
+    new_obj2frame = {}
+    next_id = 1
+
+    for inst_id, frames in obj2frame.items():
+        inst_id_int = int(inst_id)
+        idx = np.where(inst == inst_id_int)[0]
+        if idx.size == 0:
+            continue
+        pts = pc[idx, :3]
+        f_indices = [name_to_idx[f[0]] for f in frames]
+        feats = aggregate_point_features(pts, f_indices, depths, extrinsics, intrinsic, colors)
+        if feats.size == 0:
+            continue
+        clustering = DBSCAN(eps=args.eps, min_samples=args.min_samples).fit(feats)
+        labels = clustering.labels_
+        for cl in np.unique(labels):
+            if cl == -1:
+                continue
+            local_idx = idx[labels == cl]
+            out_path = views_dir / f"{args.scan}_instance_{next_id}.ply"
+            try:
+                import trimesh
+                trimesh.PointCloud(pc[local_idx, :3]).export(out_path)
+            except Exception:
+                pass
+            new_labels[local_idx] = next_id
+            new_obj2frame[str(next_id)] = frames
+            next_id += 1
+
+    np.save(views_dir / f"{args.scan}_instances_split.npy", new_labels)
+    out_file = views_dir / f"{args.scan}_object2image_split.pkl"
+    with open(out_file, "wb") as fw:
+        pickle.dump(new_obj2frame, fw)
+    print(f"Split instances written to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_split_instance_masks.py
+++ b/tests/test_split_instance_masks.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import types
+import numpy as np
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# ---- stub external heavy modules ----
+cv2 = types.SimpleNamespace(
+    imread=lambda *args, **kwargs: np.zeros((2, 2, 3), dtype=np.uint8),
+    cvtColor=lambda img, flag: img,
+    COLOR_BGR2RGB=0,
+)
+sys.modules['cv2'] = cv2
+
+class DummyContext:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+torch = types.SimpleNamespace(no_grad=lambda: DummyContext())
+sys.modules['torch'] = torch
+
+trimesh = types.SimpleNamespace(
+    load=lambda *args, **kwargs: types.SimpleNamespace(vertices=np.zeros((0, 3)), metadata={'_ply_raw': {'vertex': {'data': {'objectId': np.array([])}}}}),
+    PointCloud=lambda pts: types.SimpleNamespace(export=lambda path: None),
+)
+sys.modules['trimesh'] = trimesh
+
+# tqdm stubs
+import types as _types
+_tqdm_mod = _types.ModuleType('tqdm')
+_tqdm_mod.tqdm = lambda x, *a, **k: x
+_tqdm_contrib = _types.ModuleType('tqdm.contrib')
+_tqdm_concurrent = _types.ModuleType('tqdm.contrib.concurrent')
+_tqdm_concurrent.process_map = lambda *a, **k: None
+_tqdm_contrib.concurrent = _tqdm_concurrent
+sys.modules['tqdm'] = _tqdm_mod
+sys.modules['tqdm.contrib'] = _tqdm_contrib
+sys.modules['tqdm.contrib.concurrent'] = _tqdm_concurrent
+
+# matplotlib stub
+matplotlib_mod = _types.ModuleType('matplotlib')
+pyplot_mod = _types.ModuleType('matplotlib.pyplot')
+matplotlib_mod.pyplot = pyplot_mod
+sys.modules['matplotlib'] = matplotlib_mod
+sys.modules['matplotlib.pyplot'] = pyplot_mod
+
+# easydict stub
+ed = _types.ModuleType('easydict')
+class EasyDict(dict):
+    __getattr__ = dict.get
+    def __setattr__(self, k, v):
+        self[k] = v
+ed.EasyDict = EasyDict
+sys.modules['easydict'] = ed
+
+# open3d stub
+o3d_stub = types.SimpleNamespace(
+    geometry=types.SimpleNamespace(PointCloud=object),
+    utility=types.SimpleNamespace(Vector3dVector=lambda x: x),
+    io=types.SimpleNamespace(read_point_cloud=lambda *a, **k: None,
+                             write_point_cloud=lambda *a, **k: None),
+)
+sys.modules['open3d'] = o3d_stub
+
+# config requires dataset root
+os.makedirs('/NetworkDocker/Data/Open3DSG_trainset', exist_ok=True)
+import sys as _sys
+if 'scipy' in _sys.modules:
+    _sys.modules.pop('scipy', None)
+    _sys.modules.pop('scipy.spatial', None)
+    _sys.modules.pop('scipy.spatial.transform', None)
+import scipy  # ensure real SciPy for sklearn
+
+
+from open3dsg.data.split_instance_masks import aggregate_point_features
+
+
+def test_aggregate_point_features_rgb():
+    pts = np.array([[0.0, -0.9, 1.0], [1.0, 0.0, 1.0]], dtype=np.float32)
+    depth = (np.ones((2, 2), dtype=np.float32) * 1000).reshape(-1)
+    depths = np.array([depth])
+    extrinsics = np.array([np.eye(4, dtype=np.float32)])
+    intrinsic = np.eye(3, dtype=np.float32)
+    image = np.array([
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+    ], dtype=np.uint8)
+    images = np.array([image])
+    feats = aggregate_point_features(pts, [0], depths, extrinsics, intrinsic, images)
+    assert np.allclose(feats[0], np.array([7, 8, 9]) / 255.0)
+    assert np.allclose(feats[1], np.array([4, 5, 6]) / 255.0)


### PR DESCRIPTION
## Summary
- add `split_instance_masks.py` script to cluster instance points using RGB features and DBSCAN
- document instance mask splitting workflow in README
- test feature aggregation for instance splitting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a954c24d888320bdaef63245102bd8