### PR TITLE
Ensure graph nodes always receive a label

### DIFF
--- a/scripts/assemble_graph_assets.py
+++ b/scripts/assemble_graph_assets.py
@@ -105,7 +105,20 @@ def main() -> None:
     nodes_out = []
     for n in nodes:
         idx = int(n.get("inst_id", n.get("id")))
-        label = override_names.get(idx) or name_map.get(idx, "")
+
+        label = ""
+        for candidate in (
+            override_names.get(idx),
+            name_map.get(idx),
+            n.get("label"),
+            n.get("name"),
+        ):
+            if candidate:
+                label = str(candidate).strip()
+                if label:
+                    break
+        if not label:
+            label = str(idx)
 
         src_ply_name = Path(n.get("file", f"inst_{idx}.ply")).name
         src_ply = ply_src / src_ply_name


### PR DESCRIPTION
## Summary
- add a hierarchy of fallbacks when deriving node labels in assemble_graph_assets
- ensure every node label resolves to a non-empty string, defaulting to the node id when necessary

## Testing
- python -m compileall scripts/assemble_graph_assets.py

------
https://chatgpt.com/codex/tasks/task_e_68c94dabcd6c8320af76717838f09c46