### PR TITLE
Skip self-loop edges when assembling graph assets

### DIFF
--- a/scripts/assemble_graph_assets.py
+++ b/scripts/assemble_graph_assets.py
@@ -90,6 +90,8 @@ def main() -> None:
                 node_labels[s] = sn
             if dn:
                 node_labels[t] = dn
+            if s == t:
+                continue
             edges.append(
                 {
                     "source": s,


### PR DESCRIPTION
## Summary
- prevent `assemble_graph_assets` from adding self-loop edges while retaining node-label metadata

## Testing
- python -m compileall scripts/assemble_graph_assets.py

------
https://chatgpt.com/codex/tasks/task_e_68c9543c01b08320b7f57d651a5a4637