### PR TITLE
Optimize myset subgraph generation

### DIFF
--- a/scripts/run_myset_train.sh
+++ b/scripts/run_myset_train.sh
@@ -4,8 +4,10 @@ set -e
 ROOT=/data/Open3DSG_trainset
 OUT_GRAPH=open3dsg/output/graphs/myset
 OUT_PREPROC=open3dsg/output/preprocessed/myset
+KD_VOXEL_SIZE=0.02
 
-python open3dsg/data/gen_myset_subgraphs.py --root $ROOT --out $OUT_GRAPH --split train
+python open3dsg/data/gen_myset_subgraphs.py --root $ROOT --out $OUT_GRAPH --split train \
+  --kd_voxel_size $KD_VOXEL_SIZE
 python open3dsg/data/get_object_frame_myset.py --root $ROOT --out $OUT_PREPROC/frames --top_k 5
 python open3dsg/data/preprocess_myset.py --root $ROOT \
   --graphs $OUT_GRAPH/graphs/train.json --frames $OUT_PREPROC/frames \


### PR DESCRIPTION
## Summary
- vectorize neighbor selection in the myset subgraph builder to limit expensive distance checks while reusing the cache
- downsample instance point clouds before KD-tree construction with a configurable voxel size to keep metadata full resolution
- document the new voxel size flag in the myset training helper script

## Testing
- python -m compileall open3dsg/data/gen_myset_subgraphs.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a1fa9ec4832097384ea32f20688d